### PR TITLE
cargo: Use `resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
   "sled-utils",
 ]
 
+resolver = "2"
+
 # TODO(stevenroose) at some point probably move these inline
 [workspace.dependencies]
 # Rust stack


### PR DESCRIPTION
This makes the following warning disappear

```
warning; virtual workspace defaulting to `resolver = "1"` despire one or
more workspace members being on edition 2021 which implies `resolver="2"`
```
