### PR TITLE
Updated ark-demo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,51 +6,76 @@ An implementation of the Ark second-layer payment protocol for Bitcoin.
 This repository comprises an ASP server, `arkd`, a client wallet, `noah`, and
 a library that contains all the primitives used for these implementations.
 
-
-
-
 # Demo
 
-You can play around with the tools as follows:
-
-
-First you have to setup a regtest bitcoind node, there is a script provided for
-that. If you want to run your own node, keep in mind that for now, we need it
-to have the txindex enabled.
+The `ark_demo.sh` script creates a nice environment to play with `ark`.
 
 ```
-$ ./run_bitcoind.sh
+source ark_demo.sh
 ```
 
-You can interact with the node using `bitcoin-cli` as follows:
+First you have to setup a regtest bicoind node. If you already have a `regtest`-node
+you can use that one. You just have to ensure that `txindex` is enabled. However, the
+tutorial is easier to follow if you spin up a new regtest node.
 
 ```
-$ bitcoin-cli -regtest -rpcuser=user -rpcpassword=pass getnetworkinfo
+bd --daemon
 ```
 
-Then, you can run an arkd server:
+You can always use `type -a bd` to see what the alias does. In this case it will tell 
+you that `bd` is an alias for 
+`bitcoind -regtest -datadir=/ark/test/bitcoindatadir -server -txdindex`.
+
+You can use the `bitcoin-cli` which is aliased to `bcli` to interact with the node.     
 
 ```
-$ cargo run --bin arkd
+bcli getnetworkinfo
 ```
 
-This will start the server and it will work immediatelly. The configuration
-currently is hard-coded in the `arkd/src/main.rs` file, and can only be changed
-there. For arkd to work properly, you should fund it with some liquidity, this
-can be done by sending some money to the address that is printed out when arkd
-is started. You can send money there as follows:
+Then we create and configure an ark-server using the `arkd`-command. Our ark-server
+will run on `regtest` and use the `bitcoin`-node we've started a few lines before.
 
 ```
-$ bitcoin-cli -regtest -rpcuser=user -rpcpassword=pass generatetoaddress 1 <asp-addr>
-# Then give it 100 confirmations because it's a coinbase output.
-$ bitcoin-cli -regtest -rpcuser=user -rpcpassword=pass generatetoaddress 100 mtDDKi5mDjZqGzmbnfUnVQ8ZhCPMPVsApj
+arkd create \
+    --network regtest \
+    --datadir ./test/arkdatadir \
+    --bitcoind-url $BITCOIND_URL \
+    --bitcoind-cookie $BITCOIND_COOKIE
+```
+
+The server can be started using 
+
+```
+arkd start --datadir ./test/arkdatadir
+```
+
+The server will start working immediately but requires some funds to work properly. 
+You can find an the onchain address in the logs and send some funds to it.
+
+```
+bcli generatetoaddress 1 <asp-addr>
+```
+
+The funds are only useable after we generate 100 extra blocks.
+
+```
+bcli generatetoaddress 100 mtDDKi5mDjZqGzmbnfUnVQ8ZhCPMPVsApj
 ```
 
 Next, you can start some clients. To create a client, use the following command:
 
 ```
-$ cargo run --bin noah -- --datadir ./test/noah1 create
-$ cargo run --bin noah -- --datadir ./test/noah2 create
+noah --datadir ./test/noah1 create \
+    --regtest \
+    --asp http://localhost:35035 \
+    --bitcoind $BITCOIND_URL \
+    --bitcoind-cookie $BITCOIND_COOKIE
+
+noah --datadir ./test/noah2 create \
+    --regtest \
+    --asp http://localhost:35035 \
+    --bitcoind $BITCOIND_URL \
+    --bitcoind-cookie $BITCOIND_COOKIE
 ```
 
 These will create individual wallets and print an on-chain address you can use
@@ -58,43 +83,48 @@ to **fund them the same way as you did for the ASP above**. Note that clients
 can receive off-chain Ark transactions without having any on-chain balance, but
 a little bit of on-chain money is needed to perform unilateral exits.
 
+You can find the wallet using
+```
+NOAH1_ADDR=$(noah --datadir ./test/noah1 get-address)
+bcli generatetoaddress 1 $NOAH1_ADDR
+bcli generatetoaddress 100 mtDDKi5mDjZqGzmbnfUnVQ8ZhCPMPVsApj
+```
+
 To use the onchain wallets, there are a few commands available:
 
 ```
-$ NOAH2_ADDR=$(cargo run --bin noah -- --datadir ./test/noah2 get-address)
-$ cargo run --bin noah -- --datadir ./test/noah1 send-onchain $NOAH2_ADDR "0.1 btc"
-$ cargo run --bin noah -- --datadir ./test/noah2 balance
+NOAH2_ADDR=$(noah --datadir ./test/noah2 get-address)
+noah --datadir ./test/noah1 send-onchain $NOAH2_ADDR "0.1 btc"
+noah --datadir ./test/noah2 balance
 ```
 
 Once we have money, we can onboard into the Ark, afterwards the balance will
 also show an off-chain element.
 
 ```
-$ cargo run --bin noah -- --datadir ./test/noah1 onboard "1 btc"
-$ cargo run --bin noah -- --datadir ./test/noah1 balance
+noah --datadir ./test/noah1 onboard "1 btc"
+noah --datadir ./test/noah1 balance
 ```
 
 Remember that all txs will just be in the mempool if you don't generate blocks
 once a while...
  
 ```
-$ bitcoin-cli -regtest -rpcuser=user -rpcpassword=pass generatetoaddress 1 mtDDKi5mDjZqGzmbnfUnVQ8ZhCPMPVsApj
+bcli generatetoaddress 1 mtDDKi5mDjZqGzmbnfUnVQ8ZhCPMPVsApj
 ```
 
-Then, let's send some money off-chain to a third wallet:
+Then, let's send some money off-chain:
 
 ```
-$ cargo run --bin noah -- --datadir ./test/noah3 create
-$ cargo run --bin noah -- --datadir ./test/noah3 balance
-# Should be empty..
-$ NOAH3_PK=$(cargo run --bin noah -- --datadir ./test/noah3 get-vtxo-pubkey)
+## Should be empty..
+NOAH2_PK=$(noah --datadir ./test/noah2 get-vtxo-pubkey)
 # For now every client has just a single pubkey.
-$ echo "${NOAH3_PK}"
-$ cargo run --bin noah -- --datadir ./test/noah1 send ${NOAH3_PK} "0.1 btc"
-$ cargo run --bin noah -- --datadir ./test/noah3 balance
+echo "${NOAH2_PK}"
+noah --datadir ./test/noah1 send-round ${NOAH2_PK} "0.1 btc"
+noah --datadir ./test/noah2 balance
 ```
 
 You will notice that there is a slight delay when sending, this is because the
 client needs to wait for the start of the next round and currently no
 out-of-round payments are supported. The round interval can be changed in the
-arkd configuration.
+`arkd` configuration.

--- a/ark_demo.sh
+++ b/ark_demo.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Set up useful 
+BITCOIN_DATADIR=$PWD/test/bitcoindatadir
+BITCOIN_CLI=bitcoin-cli
+BITCOIND=bitcoind
+
+BITCOIND_RPC_PORT=18443
+BITCOIND_RPC_HOST=127.0.0.1
+BITCOIND_URL=http://${BITCOIND_RPC_HOST}:${BITCOIND_RPC_PORT}
+BITCOIND_COOKIE=$PWD/test/bitcoindatadir/regtest/.cookie
+
+mkdir -p ${BITCOIN_DATADIR}
+
+# Define useful aliases
+alias bcli="$BITCOIN_CLI -regtest --rpcport=$BITCOIND_RPC_PORT --rpccookiefile=$BITCOIND_COOKIE"
+alias arkd="cargo run --bin arkd --"
+alias noah="cargo run --bin noah --"
+alias bd="$BITCOIND -regtest -datadir=${BITCOIN_DATADIR} -server -txindex"
+
+# Print some help and documentation 
+echo "-------------------------------------------"
+echo "- Ark Demo                                -"
+echo "-------------------------------------------"
+echo ""
+echo "This script is useful to test and demo ark "
+echo "on regtest. The script will help you to set-up"
+echo "an ASP and a couple of clients that can send"
+echo "ark payments to each-other."
+echo ""
+echo ""
+echo "The following aliases have been defined"
+echo "- \`bd\`: To run and start \`bitcoind\`"
+echo "- \`bcli\`: Use \`bitcoin-cli\` on your \`bitcoind\`"
+echo "- \`arkd\`: Compiles and runs \`arkd\`"
+echo "- \`noah\`: Compiles and runs \`noah\`"
+echo ""

--- a/run_bitcoind.sh
+++ b/run_bitcoind.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-
-datadir=./test/bitcoindatadir
-mkdir -p ${datadir}
-
-bitcoind -regtest -datadir=${datadir} -server -txindex


### PR DESCRIPTION
The `README.md` filed contained a small demo scenario. The scenario was
somewhat out-dated and needed an update.

I've reworked the `run_bitcoind.sh` script and renamed it to
`ark_demo.sh`. Instead of starting `bitcoind` it creates a demo
environment useful aliases.

All bash lines started with `$`. It looks prettier but I decided to
remove it in favour of mindless copy paste.
