### PR TITLE
Add script to generate rust docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 debug/
 target/
 .direnv/
+rustdocs/

--- a/gendocs.sh
+++ b/gendocs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+RUSTDOCSDIR=${PWD}/rustdocs
+mkdir -p ${RUSTDOCSDIR}
+
+cargo doc --target-dir ${RUSTDOCSDIR} --all --lib --examples --document-private-items
+
+# This is opinionated, but doesn't matter. Any page has full search.
+DEFAULT_CRATE=noah
+echo "Open Rust docs at file://${RUSTDOCSDIR}/doc/${DEFAULT_CRATE}/index.html"


### PR DESCRIPTION
Generates a folder `./rustdocs` with all the documentation of our crates and all dependent crates.