### PR TITLE
Consistently use 3535 for the admin-api port

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Next, you can start some clients. To create a client, use the following command:
 ```
 noah --datadir ./test/noah1 create \
     --regtest \
-    --asp http://localhost:35035 \
+    --asp http://localhost:3535 \
     --bitcoind $BITCOIND_URL \
     --bitcoind-cookie $BITCOIND_COOKIE
 
 noah --datadir ./test/noah2 create \
     --regtest \
-    --asp http://localhost:35035 \
+    --asp http://localhost:3535 \
     --bitcoind $BITCOIND_URL \
     --bitcoind-cookie $BITCOIND_COOKIE
 ```

--- a/arkd/src/main.rs
+++ b/arkd/src/main.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use arkd::{App, Config};
 use arkd_rpc_client as rpc;
 
-const RPC_ADDR: &str = "[::]:35035";
+const RPC_ADDR: &str = "[::]:3535";
 
 #[derive(Parser)]
 #[command(author = "Steven Roose <steven@roose.io>", version, about)]


### PR DESCRIPTION
`arkd` uses 3535 as a default for the admin-api.
`noah` and the tutorial referred to `35035`.

We should use `3535` everywhere
