### PR TITLE
Test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "bitcoind",
  "env_logger",
  "log",
+ "portpicker",
  "rand",
 ]
 
@@ -467,15 +468,6 @@ name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1582,6 +1574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portpicker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,7 +1921,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.14.0",
  "rand",
  "secp256k1-sys 0.10.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,9 @@ name = "ark-testing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitcoin",
  "log",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-testing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "log",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitcoin",
+ "env_logger",
  "log",
  "rand",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitcoin",
+ "bitcoind",
  "env_logger",
  "log",
  "rand",
@@ -518,6 +519,19 @@ dependencies = [
  "bitcoin",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bitcoind"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee5cf6a9903ff9cc808494c1232b0e9f6eef6600913d0d69fe1cb5c428f25b9"
+dependencies = [
+ "anyhow",
+ "bitcoincore-rpc",
+ "log",
+ "tempfile",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 
 [workspace]
 members = [
+  "ark-testing",
   "ark-lib",
   "aspd-rpc-client",
   "aspd",
   "bark",
-
   "sled-utils",
 ]
 

--- a/ark-testing/Cargo.toml
+++ b/ark-testing/Cargo.toml
@@ -10,3 +10,4 @@ rand.workspace = true
 bitcoin.workspace = true
 env_logger.workspace = true
 bitcoind = "0.36.0"
+portpicker = "0.1.1"

--- a/ark-testing/Cargo.toml
+++ b/ark-testing/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ark-testing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+log.workspace = true

--- a/ark-testing/Cargo.toml
+++ b/ark-testing/Cargo.toml
@@ -8,3 +8,4 @@ anyhow.workspace = true
 log.workspace = true
 rand.workspace = true
 bitcoin.workspace = true
+env_logger.workspace = true

--- a/ark-testing/Cargo.toml
+++ b/ark-testing/Cargo.toml
@@ -9,3 +9,4 @@ log.workspace = true
 rand.workspace = true
 bitcoin.workspace = true
 env_logger.workspace = true
+bitcoind = "0.36.0"

--- a/ark-testing/Cargo.toml
+++ b/ark-testing/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 log.workspace = true
+rand.workspace = true
+bitcoin.workspace = true

--- a/ark-testing/src/aspd.rs
+++ b/ark-testing/src/aspd.rs
@@ -1,7 +1,20 @@
+use std::borrow::Borrow;
 use std::env::VarError;
+use std::process::Command;
+
+use std::fmt;
+use std::fs;
+use std::fs::create_dir_all;
+use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+use std::io::prelude::*;
+
+use anyhow::Result;
 
 use crate::cmd::BaseCommand;
 use crate::constants::env::ASPD_EXEC;
+use crate::error::Error;
+use crate::runner::{RuntimeData, RunnerHelper, DaemonRunner};
 
 pub fn get_base_cmd() -> anyhow::Result<BaseCommand> {
 	match std::env::var(ASPD_EXEC) {
@@ -22,4 +35,148 @@ pub fn get_base_cmd() -> anyhow::Result<BaseCommand> {
 			Err(anyhow::anyhow!("{} is not valid unicode", ASPD_EXEC))
 		}
 	}
+}
+
+pub struct AspD {
+	name: String,
+	arkd_cmd: BaseCommand,
+	datadir: PathBuf,
+	bitcoind_cookie: PathBuf,
+	bitcoind_url: String,
+	network: bitcoin::Network,
+	runtime_data: Option<Arc<Mutex<RuntimeData<State>>>>
+}
+
+impl AspD {
+
+	pub fn new<B>(name: String, arkd_cmd: BaseCommand, datadir: PathBuf, bitcoind: B) -> Self 
+		where B : Borrow<bitcoind::BitcoinD>
+	{
+		Self {
+			name,
+			arkd_cmd,
+			datadir,
+			bitcoind_cookie: bitcoind.borrow().params.cookie_file.clone(),
+			bitcoind_url: bitcoind.borrow().params.rpc_socket.to_string(),
+			network: bitcoin::Network::Regtest,
+			runtime_data: None,
+		}
+	}
+}
+
+impl fmt::Debug for AspD {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "{:?} --datadir {:?}", self.arkd_cmd, self.datadir)
+	}
+}
+
+#[derive(Debug)]
+pub struct State{
+	stdout: Option<fs::File>,
+	stderr: Option<fs::File>
+}
+
+impl State {
+
+	fn process_stdout(&mut self, name: &str, line: &str) {
+		match &mut self.stdout {
+			Some(file) => { 
+				let _ = write!(file, "{} - {}\n", name, line);},
+			_ => {}
+		}
+	}
+
+	fn process_stderr(&mut self, line: &str) {
+		match &mut self.stderr {
+			Some(file) => {
+				let _ = write!(file, "{}\n", line);
+			},
+			None => {}
+		}
+	}
+}
+
+impl RunnerHelper for AspD {
+	type State = State;
+
+	fn _prepare(&mut self) -> Result<(), Error> {
+		trace!("_prepare {}", self.name);
+		create_dir_all(self.datadir.clone()).unwrap();
+
+		// Create and initialize the datadir
+		let network = self.network.to_string();
+		let mut cmd = self.arkd_cmd.get_cmd();
+		cmd
+			.arg("create")
+			.arg("--datadir")
+			.arg(self.datadir.clone())
+			.arg("--bitcoind-url")
+			.arg(self.bitcoind_url.clone())
+			.arg("--bitcoind-cookie")
+			.arg(self.bitcoind_cookie.clone())
+			.arg("--network")
+			.arg(network);
+
+		let output = cmd.output()?;
+		if output.status.success() {
+			info!("Created {}", self.name)
+		}
+		else {
+			error!("Created arkd with stderr: {}", std::str::from_utf8(&output.stderr).unwrap());
+			panic!("Failed to create {}", self.name)
+		}
+
+		Ok(())
+	}
+
+	fn _command(&self) -> Command {
+		let mut command = self.arkd_cmd.get_cmd();
+		command
+			.arg("start")
+			.arg("--datadir")
+			.arg(self.datadir.clone());
+
+		command
+	}
+
+
+	fn _process_stdout(name: &str, state: &mut Self::State, line: &str) {
+		state.process_stdout(name, line);
+	}
+
+
+	fn _process_stderr(state: &mut Self::State, line: &str) {
+		state.process_stderr(line);
+	}
+
+	fn _init_state(&self) -> Self::State {
+		// Create the log-files
+		let stdout = fs::OpenOptions::new()
+			.append(true)
+			.create(true)
+			.open(self.datadir.join("stdout.log")).unwrap();
+
+		let stderr = fs::OpenOptions::new()
+			.append(true)
+			.create(true)
+			.open(self.datadir.join("stderr.log")).unwrap();
+
+
+		Self::State { 
+			stdout: Some(stdout),
+			stderr: Some(stderr)
+		}
+	}
+
+	fn _get_runtime(&self) -> Option<Arc<Mutex<RuntimeData<Self::State>>>>	{
+		self.runtime_data.clone()
+	}
+
+	fn _notif_started(&mut self, runtime_data: Arc<Mutex<RuntimeData<Self::State>>>) {
+		self.runtime_data.replace(runtime_data);
+	}
+}
+
+impl DaemonRunner for AspD {
+
 }

--- a/ark-testing/src/aspd.rs
+++ b/ark-testing/src/aspd.rs
@@ -1,0 +1,25 @@
+use std::env::VarError;
+
+use crate::cmd::BaseCommand;
+use crate::constants::env::ASPD_EXEC;
+
+pub fn get_base_cmd() -> anyhow::Result<BaseCommand> {
+	match std::env::var(ASPD_EXEC) {
+		Ok(var) => {
+			Ok(BaseCommand::new(var, vec![]))
+		},
+		Err(VarError::NotPresent) => {
+			let cmd = BaseCommand::new(
+				"cargo".to_string(),
+				["run", "--package", "bark-aspd", "--"]
+				.iter()
+				.map(|x| x.to_string())
+				.collect()
+			);
+			Ok(cmd)
+		},
+		Err(VarError::NotUnicode(_)) => {
+			Err(anyhow::anyhow!("{} is not valid unicode", ASPD_EXEC))
+		}
+	}
+}

--- a/ark-testing/src/bark.rs
+++ b/ark-testing/src/bark.rs
@@ -1,0 +1,25 @@
+use std::env::VarError;
+
+use crate::cmd::BaseCommand;
+use crate::constants::env::BARK_EXEC;
+
+pub fn get_base_cmd() -> anyhow::Result<BaseCommand> {
+	match std::env::var(BARK_EXEC) {
+		Ok(var) => {
+			Ok(BaseCommand::new(var, vec![]))
+		},
+		Err(VarError::NotPresent) => {
+			let cmd = BaseCommand::new(
+				"cargo".to_string(),
+				["run", "--package", "bark-client", "--"]
+					.iter()
+					.map(|x| x.to_string())
+					.collect()
+			);
+			Ok(cmd)
+		},
+		Err(VarError::NotUnicode(_)) => {
+			Err(anyhow::anyhow!("{} is not valid unicode", BARK_EXEC))
+		}
+	}
+}

--- a/ark-testing/src/cmd.rs
+++ b/ark-testing/src/cmd.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct BaseCommand {
+	exe_path: String,
+	default_args: Vec<String>
+}
+
+impl BaseCommand {
+
+	pub fn new(exe_path: String, default_args: Vec<String>) -> Self {
+		Self { exe_path, default_args}
+	}
+
+	pub fn get_cmd(&self) -> std::process::Command {
+		let mut cmd = Command::new(self.exe_path.clone());
+		cmd.args(&self.default_args);
+		cmd
+	}
+}

--- a/ark-testing/src/constants.rs
+++ b/ark-testing/src/constants.rs
@@ -1,0 +1,6 @@
+
+
+pub mod env {
+	pub const ASPD_EXEC : &str = "ASPD_EXEC";
+	pub const BARK_EXEC: &str = "BARK_EXEC";
+}

--- a/ark-testing/src/constants.rs
+++ b/ark-testing/src/constants.rs
@@ -1,6 +1,6 @@
-
-
 pub mod env {
 	pub const ASPD_EXEC : &str = "ASPD_EXEC";
 	pub const BARK_EXEC: &str = "BARK_EXEC";
+	pub const TEST_TMP_DIR: &str = "TEST_TMP_DIR";
+	pub const TEST_LEAVE_INTACT: &str = "TEST_LEAVE_INTACT";
 }

--- a/ark-testing/src/error.rs
+++ b/ark-testing/src/error.rs
@@ -1,0 +1,38 @@
+use std::{error, fmt, io, process};
+
+#[derive(Debug)]
+pub enum Error {
+	/// An I/O error.
+	Io(io::Error),
+	/// Invalid configuration provided.
+	Config(&'static str),
+	/// A Bitcoin Core RPC error.
+	/// Any other error.
+	Custom(&'static str),
+	/// The daemon is not in the appropriate state for this action.
+	InvalidState(crate::runner::Status),
+	/// Error running a command.
+	RunCommand(io::Error, process::Command),
+}
+
+impl From<io::Error> for Error {
+	fn from(e: io::Error) -> Error {
+		Error::Io(e)
+	}
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		fmt::Debug::fmt(self, f)
+	}
+}
+
+impl error::Error for Error {
+	fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+		match *self {
+			Error::Io(ref e) => Some(e),
+			Error::RunCommand(ref e, ..) => Some(e),
+			Error::Config(_) | Error::Custom(_) | Error::InvalidState(_) => None,
+		}
+	}
+}

--- a/ark-testing/src/lib.rs
+++ b/ark-testing/src/lib.rs
@@ -17,7 +17,17 @@ impl TestContext {
 
 	pub fn new(name: String, base_path: PathBuf) -> Self {
 		fs::create_dir_all(base_path.clone()).unwrap();
-		TestContext { name, datadir: base_path}
+		let context = TestContext { name, datadir: base_path};
+		context.init_logging().unwrap();
+		context
+	}
+
+	pub fn init_logging(&self) -> anyhow::Result<()> {
+		// We ignore the output
+		// An error is returned if the logger is initiated twice
+		// Note, that every test tries to initiate the logger
+		let _ = env_logger::builder().is_test(true).try_init();
+		Ok(())
 	}
 
 	pub fn generate() -> Self {
@@ -25,6 +35,7 @@ impl TestContext {
 		let datadir = ["/tmp/ark-testing/", &name].iter().collect();
 		Self::new(name, datadir)
 	}
+
 }
 
 impl Drop for TestContext {
@@ -32,12 +43,12 @@ impl Drop for TestContext {
 		// Remove the data-directory
 		// If the user has set `LEAVE_INTACT` we don't delete any 
 		// test-data.
-
 		if std::env::var(constants::env::TEST_LEAVE_INTACT).is_ok() {
+			log::info!("Leaving test-context intact at {:?}", self.datadir);
 			return
 		}
 		if self.datadir.exists() {
-			log::info!("Test clean-up");
+			log::trace!("Cleaning up test-context. Run again with `TEST_LEAVE_INTACT=1` to keep the test intact");
 			std::fs::remove_dir_all(self.datadir.clone()).unwrap();
 		}
 	}
@@ -56,7 +67,7 @@ mod test {
 				assert!(context.datadir.exists());
 				drop(context);
 
-				// The test cleans up after itself
+				// The test cleans up after itself if TEST_LEAVE_INTACT is not set
 				match std::env::var(constants::env::TEST_LEAVE_INTACT) {
 					Ok(_) => assert!(base_path.exists()),
 					Err(_) => assert!(!base_path.exists())

--- a/ark-testing/src/lib.rs
+++ b/ark-testing/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod aspd;
+pub mod cmd;
+pub mod constants;
+pub mod bark;

--- a/ark-testing/src/lib.rs
+++ b/ark-testing/src/lib.rs
@@ -4,12 +4,16 @@ pub mod aspd;
 pub mod cmd;
 pub mod constants;
 pub mod bark;
+
+mod error;
+mod runner;
 mod util;
 
 use std::path::PathBuf;
 use std::fs;
 pub use bitcoind;
 use bitcoind::BitcoinD;
+pub use runner::DaemonRunner;
 
 pub struct TestContext {
 	#[allow(dead_code)]

--- a/ark-testing/src/lib.rs
+++ b/ark-testing/src/lib.rs
@@ -23,10 +23,13 @@ impl TestContext {
 	}
 
 	pub fn init_logging(&self) -> anyhow::Result<()> {
-		// We ignore the output
-		// An error is returned if the logger is initiated twice
-		// Note, that every test tries to initiate the logger
-		let _ = env_logger::builder().is_test(true).try_init();
+		// We ignore the error
+		// It is only returned when the logger is initiated twice
+		// Note, that every test tries to initiate the logger 
+		// so this happens all the time
+		let _ = env_logger::Builder::from_env(
+			env_logger::Env::default().default_filter_or("trace"))
+			.is_test(true).try_init();
 		Ok(())
 	}
 

--- a/ark-testing/src/lib.rs
+++ b/ark-testing/src/lib.rs
@@ -2,3 +2,64 @@ pub mod aspd;
 pub mod cmd;
 pub mod constants;
 pub mod bark;
+mod util;
+
+use std::path::PathBuf;
+use std::fs;
+
+pub struct TestContext {
+	#[allow(dead_code)]
+	name: String,
+	datadir: PathBuf
+}
+
+impl TestContext {
+
+	pub fn new(name: String, base_path: PathBuf) -> Self {
+		fs::create_dir_all(base_path.clone()).unwrap();
+		TestContext { name, datadir: base_path}
+	}
+
+	pub fn generate() -> Self {
+		let name = util::random_string();
+		let datadir = ["/tmp/ark-testing/", &name].iter().collect();
+		Self::new(name, datadir)
+	}
+}
+
+impl Drop for TestContext {
+	fn drop(&mut self) {
+		// Remove the data-directory
+		// If the user has set `LEAVE_INTACT` we don't delete any 
+		// test-data.
+
+		if std::env::var(constants::env::TEST_LEAVE_INTACT).is_ok() {
+			return
+		}
+		if self.datadir.exists() {
+			log::info!("Test clean-up");
+			std::fs::remove_dir_all(self.datadir.clone()).unwrap();
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+		#[test]
+		fn context_creates_and_deletes_datadir() {
+				let context = TestContext::generate();
+				let base_path = context.datadir.clone();
+
+				// The base-path is created
+				assert!(context.datadir.exists());
+				drop(context);
+
+				// The test cleans up after itself
+				match std::env::var(constants::env::TEST_LEAVE_INTACT) {
+					Ok(_) => assert!(base_path.exists()),
+					Err(_) => assert!(!base_path.exists())
+				}
+		}
+}

--- a/ark-testing/src/runner.rs
+++ b/ark-testing/src/runner.rs
@@ -58,8 +58,8 @@ pub trait RunnerHelper {
 	/// This is called after the [_prepare] method is called.
 	fn _init_state(&self) -> Self::State;
 
-	/// Notify that the daemon has started.
-	fn _notif_started(&mut self, runtime_data: Arc<Mutex<RuntimeData<Self::State>>>);
+	/// Notify that the daemon will start soon
+	fn _notif_starting(&mut self, runtime_data: Arc<Mutex<RuntimeData<Self::State>>>);
 
 	/// Get the current runtime data.
 	fn _get_runtime(&self) -> Option<Arc<Mutex<RuntimeData<Self::State>>>>;
@@ -112,7 +112,7 @@ where
 					}
 					trace!("Thread {} stopped", thread::current().name().unwrap());
 				})
-				.expect(&format!("failed to start stdout read thread")),
+				.expect("failed to start stdout read thread"),
 		);
 
 		// Start stderr processing thread.
@@ -128,7 +128,7 @@ where
 					}
 					trace!("Thread {} stopped", thread::current().name().unwrap());
 				})
-				.expect(&format!("failed to start stderr read thread")),
+				.expect("failed to start stderr read thread"),
 		);
 
 		info!("Daemon {:?} started. PID: {}", self, pid);
@@ -157,8 +157,9 @@ where
 			state: self._init_state(),
 		}));
 
-		self._start_up(rt.clone())?;
-		self._notif_started(rt);
+
+		self._notif_starting(rt.clone());
+		self._start_up(rt)?;
 		Ok(())
 	}
 

--- a/ark-testing/src/runner.rs
+++ b/ark-testing/src/runner.rs
@@ -1,0 +1,208 @@
+use std::io::BufRead;
+use std::sync::{Arc, Mutex};
+use std::{fmt, io, ops, process, thread, time};
+
+use crate::error::Error;
+
+/// An wrapper for child that is killed when it's dropped.
+struct KillOnDropChild(process::Child);
+
+impl KillOnDropChild {
+	pub fn get(&self) -> &process::Child {
+		&self.0
+	}
+	pub fn get_mut(&mut self) -> &mut process::Child {
+		&mut self.0
+	}
+}
+
+impl ops::Drop for KillOnDropChild {
+	fn drop(&mut self) {
+		// We don't care about the error here because we probably
+		// already safely stopped the process.
+		let _ = self.0.kill();
+	}
+}
+
+pub struct RuntimeData<S> {
+	pub state: S,
+
+	process: Option<KillOnDropChild>,
+	stdout_thread: Option<thread::JoinHandle<()>>,
+	stderr_thread: Option<thread::JoinHandle<()>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+	Init,
+	Running,
+	Stopped(process::ExitStatus),
+}
+
+/// Methods in this trait are intended to be used only
+/// by the [DaemonRunner] implementation.
+#[doc(hidden)]
+pub trait RunnerHelper {
+	type State;
+
+	/// Prepare the daemon for running.
+	///
+	/// This is called before the [_init_state] method is called.
+	fn _prepare(&mut self) -> Result<(), Error>;
+
+	/// The command to run.
+	fn _command(&self) -> process::Command;
+
+	/// Create the initial state.
+	///
+	/// This is called after the [_prepare] method is called.
+	fn _init_state(&self) -> Self::State;
+
+	/// Notify that the daemon has started.
+	fn _notif_started(&mut self, runtime_data: Arc<Mutex<RuntimeData<Self::State>>>);
+
+	/// Get the current runtime data.
+	fn _get_runtime(&self) -> Option<Arc<Mutex<RuntimeData<Self::State>>>>;
+
+	/// Process some lines of stdout output.
+	/// All lines not processed will be discarded.
+	fn _process_stdout(name: &str, state: &mut Self::State, line: &str);
+
+	/// Process some lines of stderr output.
+	/// All lines not processed will be discarded.
+	fn _process_stderr(state: &mut Self::State, line: &str);
+}
+
+pub trait DaemonRunner: RunnerHelper + fmt::Debug + Sized
+where
+	<Self as RunnerHelper>::State: 'static + Send,
+{
+	/// The actual startup function.
+	/// This intended for internal use only, use [start] and [restart] instead.
+	fn _start_up(&self, rt: Arc<Mutex<RuntimeData<Self::State>>>) -> Result<(), Error> {
+		info!("Starting daemon {:?}...", self);
+
+		let mut cmd = self._command();
+		cmd.stdout(process::Stdio::piped());
+		cmd.stderr(process::Stdio::piped());
+		debug!("Launching daemon {:?} with command: {:?}", self, cmd);
+		let mut process = KillOnDropChild(cmd.spawn().map_err(|e| Error::RunCommand(e, cmd))?);
+		let pid = process.get().id();
+
+		let stdout = process.0.stdout.take().unwrap();
+		let stderr = process.0.stderr.take().unwrap();
+
+		let mut rt_lock = rt.lock().unwrap();
+		rt_lock.process = Some(process);
+
+		// Start stdout processing thread.
+		let rt_cloned = rt.clone();
+		rt_lock.stdout_thread.replace(
+			thread::Builder::new()
+				.name(format!("{:?}_stdout", self))
+				.spawn(move || {
+					thread::sleep(time::Duration::from_secs(1));
+					let buf_read = io::BufReader::new(stdout);
+					for line in buf_read.lines() {
+						Self::_process_stdout(
+							thread::current().name().unwrap(),
+							&mut rt_cloned.lock().unwrap().state,
+							&line.unwrap(),
+						);
+					}
+					trace!("Thread {} stopped", thread::current().name().unwrap());
+				})
+				.expect(&format!("failed to start stdout read thread")),
+		);
+
+		// Start stderr processing thread.
+		let rt_cloned = rt.clone();
+		rt_lock.stderr_thread.replace(
+			thread::Builder::new()
+				.name(format!("{:?}_stderr", self))
+				.spawn(move || {
+					thread::sleep(time::Duration::from_secs(1));
+					let buf_read = io::BufReader::new(stderr);
+					for line in buf_read.lines() {
+						Self::_process_stderr(&mut rt_cloned.lock().unwrap().state, &line.unwrap());
+					}
+					trace!("Thread {} stopped", thread::current().name().unwrap());
+				})
+				.expect(&format!("failed to start stderr read thread")),
+		);
+
+		info!("Daemon {:?} started. PID: {}", self, pid);
+		Ok(())
+	}
+
+	/// Start the daemon for the first time.
+	///
+	/// If the daemon was previously stopped, this method simply restarts it.
+	fn start(&mut self) -> Result<(), Error> {
+		match self.status()? {
+			Status::Running => return Ok(()), // already running
+			Status::Stopped(_) => {
+				// Simply restart.
+				return self._start_up(self._get_runtime().unwrap());
+			}
+			Status::Init => {} // fall through
+		}
+
+		self._prepare()?;
+
+		let rt = Arc::new(Mutex::new(RuntimeData {
+			process: None,
+			stdout_thread: None,
+			stderr_thread: None,
+			state: self._init_state(),
+		}));
+
+		self._start_up(rt.clone())?;
+		self._notif_started(rt);
+		Ok(())
+	}
+
+	/// Stop the daemon.
+	/// State is preserved so that it can be restarted with [restart].
+	/// If the daemon already stopped, this is a no-op.
+	fn stop(&self) -> Result<(), Error> {
+		match self.status()? {
+			Status::Init => return Err(Error::InvalidState(Status::Init)),
+			Status::Running => {}
+			Status::Stopped(_) => return Ok(()),
+		}
+
+		let rt_ref = self._get_runtime().unwrap();
+		let mut rt = rt_ref.lock().unwrap();
+
+		info!("Stopping daemon {:?}...", self);
+		let proc = rt.process.as_mut().unwrap().get_mut();
+		proc.kill()?;
+		proc.wait()?;
+
+		info!("Daemon {:?} stopped", self);
+		Ok(())
+	}
+
+	/// The the running status of the daemon.
+	fn status(&self) -> Result<Status, Error> {
+		let rt = match self._get_runtime() {
+			Some(rt) => rt,
+			None => return Ok(Status::Init),
+		};
+
+		let mut lock = rt.lock().unwrap();
+		match lock.process.as_mut().unwrap().0.try_wait()? {
+			None => Ok(Status::Running),
+			Some(c) => Ok(Status::Stopped(c)),
+		}
+	}
+
+	/// Get the OS process ID of the daemon.
+	fn pid(&self) -> Option<u32> {
+		self._get_runtime().map(|rt| rt.lock().unwrap().process.as_ref().unwrap().get().id())
+	}
+
+	//TODO(stevenroose) try make a generic method
+	// fn state(&self) -> Option<XXX> where XXX has Deref<Self::State> somehow
+}

--- a/ark-testing/src/util.rs
+++ b/ark-testing/src/util.rs
@@ -1,0 +1,9 @@
+use rand::RngCore;
+
+pub fn random_string() -> String {
+	// Generate a few random bytes and base58 encode them
+	// The entropy should be sufficient to generate unique test-names
+	let mut entropy :[u8; 8] = [0; 8];
+	rand::thread_rng().fill_bytes(&mut entropy);
+	bitcoin::base58::encode(&entropy)
+}

--- a/ark-testing/tests/aspd.rs
+++ b/ark-testing/tests/aspd.rs
@@ -1,7 +1,7 @@
-
 #[macro_use] extern crate log;
 
 use ark_testing::aspd;
+use ark_testing::TestContext;
 
 #[test]
 fn test_arkd_version() {
@@ -15,4 +15,20 @@ fn test_arkd_version() {
 
 	println!("{}", stderr_str);
   assert!(stdout_str.starts_with("bark-aspd"));
+}
+
+#[test]
+fn fund_aspd() {
+	let mut ctx = TestContext::generate();
+	log::info!("Initialized TestContext");
+	let bitcoind = ctx.bitcoind();
+	let aspd = ctx.aspd(&bitcoind);
+
+	// We should wait until aspd is ready
+	// TODO: Ensure ctx.aspd(&bitcoind) only returns once the `aspd` is useable
+	std::thread::sleep(std::time::Duration::from_secs(2));
+
+	let adm_addr = format!("http://localhost:{}", aspd.admin_rpc_port().expect("The port is available"));
+  let balance = aspd.run_cmd_with_args(&["rpc", "--addr", &adm_addr, "balance"]).expect("Can retrieve balance");
+  assert_eq!(balance,  "0 BTC\n");
 }

--- a/ark-testing/tests/aspd.rs
+++ b/ark-testing/tests/aspd.rs
@@ -1,0 +1,18 @@
+
+#[macro_use] extern crate log;
+
+use ark_testing::aspd;
+
+#[test]
+fn test_arkd_version() {
+	let mut cmd = aspd::get_base_cmd().unwrap().get_cmd();
+	cmd.arg("--version");
+
+	trace!("Executing {:?}", cmd);
+	let output = cmd.output().unwrap();
+	let stdout_str = std::str::from_utf8(&output.stdout).unwrap();
+	let stderr_str = std::str::from_utf8(&output.stderr).unwrap();
+
+	println!("{}", stderr_str);
+  assert!(stdout_str.starts_with("bark-aspd"));
+}

--- a/ark-testing/tests/bark.rs
+++ b/ark-testing/tests/bark.rs
@@ -1,0 +1,19 @@
+#[macro_use] extern crate log;
+
+use ark_testing::bark;
+
+#[test]
+fn test_bark_version() {
+	let mut cmd = bark::get_base_cmd().unwrap().get_cmd();
+	cmd.arg("--version");
+
+	trace!("Executing {:?}", cmd);
+	let output = cmd.output().unwrap();
+	let stdout_str = std::str::from_utf8(&output.stdout).unwrap();
+	let stderr_str = std::str::from_utf8(&output.stderr).unwrap();
+
+	println!("{}", stderr_str);
+
+	assert!(stdout_str.starts_with("bark-client"));
+}
+

--- a/aspd/src/lib.rs
+++ b/aspd/src/lib.rs
@@ -213,6 +213,7 @@ impl App {
 			(ret, db)
 		};
 
+		debug!("Connecting to bitcoind at {} with cookie {}", &config.bitcoind_url, config.bitcoind_cookie);
 		let bitcoind = bdk_bitcoind_rpc::bitcoincore_rpc::Client::new(
 			&config.bitcoind_url,
 			bdk_bitcoind_rpc::bitcoincore_rpc::Auth::CookieFile(config.bitcoind_cookie.as_str().into()),
@@ -232,6 +233,7 @@ impl App {
 	}
 
 	pub fn start(self: &mut Arc<Self>) -> anyhow::Result<tokio::task::JoinHandle<anyhow::Result<()>>> {
+		log::trace!("Starting the asp");
 		let mut_self = Arc::get_mut(self).context("can only start if we are unique Arc")?;
 
 		let (round_event_tx, _rx) = tokio::sync::broadcast::channel(8);

--- a/aspd/src/main.rs
+++ b/aspd/src/main.rs
@@ -171,7 +171,9 @@ async fn inner_main() -> anyhow::Result<()> {
 			println!("You should restart `arkd` to ensure the new configuration takes effect");
 		},
 		Command::Start => {
+			info!("Called start");
 			let mut app = App::open(&cli.datadir.context("need datadir")?).context("server init")?;
+			debug!("Open application");
 			let jh = app.start()?;
 			info!("aspd onchain address: {}", app.onchain_address().await?);
 			if let Err(e) = jh.await? {

--- a/bark/src/onchain/chain.rs
+++ b/bark/src/onchain/chain.rs
@@ -7,6 +7,7 @@ use bitcoin::{OutPoint, Transaction};
 
 const TX_ALREADY_IN_CHAIN_ERROR: i32 = -27;
 
+#[derive(Debug, Clone)]
 pub enum ChainSource {
 	Bitcoind {
 		url: String,
@@ -24,6 +25,7 @@ pub enum ChainSourceClient {
 
 impl ChainSourceClient {
 	pub fn new(chain_source: ChainSource) -> anyhow::Result<Self> {
+		log::debug!("Creating client for source {:?}", chain_source);
 		Ok(match chain_source {
 			ChainSource::Bitcoind { url, auth } => ChainSourceClient::Bitcoind(
 				bitcoincore_rpc::Client::new(&url, auth)


### PR DESCRIPTION
The introduction of a test framework for `bark` and `bark-aspd`.

It has the following requriements
- Easy to define integration tests
- It should be easy to debug failed integration tests. `TEST_LEAVE_INTACT` can be used to inspect the state of `bitcoind`, `aspd` and all `bark`-clients at the end of the test.
- It should be easy to swap versions of all executables. This allows us to test `aspd` with older client-versions which helps us to ensure backward compatibility