### PR TITLE
Start refactoring round coordination

### DIFF
--- a/aspd/src/lib.rs
+++ b/aspd/src/lib.rs
@@ -22,7 +22,7 @@ use anyhow::Context;
 use bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi;
 use bitcoin::{bip32, sighash, psbt, taproot, Amount, Address, OutPoint, Transaction, Witness};
 use bitcoin::secp256k1::{self, Keypair};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 
 use ark::util::KeypairExt;
 use ark::musig;
@@ -57,7 +57,6 @@ pub struct Config {
 }
 
 impl Config {
-
 	pub fn read_from_datadir<P: AsRef<Path>>(datadir: P) -> anyhow::Result<Self> {
 		let path = datadir.as_ref().join("config.json");
 		trace!("Reading configuraton from file {}", path.display());
@@ -119,10 +118,6 @@ impl Default for Config {
 }
 
 pub struct RoundHandle {
-	/// Whenever a round is going on, this lock will be held.
-	/// This helps us schedule tasks like db cleanups without
-	/// interfering with rounds.
-	round_busy: RwLock<()>,
 	round_event_tx: tokio::sync::broadcast::Sender<RoundEvent>,
 	round_input_tx: tokio::sync::mpsc::UnboundedSender<RoundInput>,
 	round_trigger_tx: tokio::sync::mpsc::Sender<()>,
@@ -239,7 +234,6 @@ impl App {
 		let (round_trigger_tx, round_trigger_rx) = tokio::sync::mpsc::channel(1);
 
 		mut_self.rounds = Some(RoundHandle {
-			round_busy: RwLock::new(()),
 			round_event_tx: round_event_tx,
 			round_input_tx: round_input_tx,
 			round_trigger_tx: round_trigger_tx,

--- a/aspd/src/lib.rs
+++ b/aspd/src/lib.rs
@@ -138,7 +138,7 @@ pub struct App {
 	//NB only take this lock when you already have the above lock to avoid deadlock
 	wallet_db: Mutex<bdk_file_store::Store::<bdk_wallet::wallet::ChangeSet>>,
 	bitcoind: bdk_bitcoind_rpc::bitcoincore_rpc::Client,
-	
+
 	rounds: Option<RoundHandle>,
 }
 
@@ -256,7 +256,7 @@ impl App {
 					ret = rpcserver::run_admin_rpc_server(app.clone()) => {
 						ret.context("error from admin gRPC server")
 					},
-					ret = round::run_round_scheduler(app.clone(), round_input_rx, round_trigger_rx) => {
+					ret = round::run_round_coordinator(app.clone(), round_input_rx, round_trigger_rx) => {
 						ret.context("error from round scheduler")
 					},
 				}
@@ -265,7 +265,7 @@ impl App {
 					ret = rpcserver::run_public_rpc_server(app.clone()) => {
 						ret.context("error from public gRPC server")
 					},
-					ret = round::run_round_scheduler(app.clone(), round_input_rx, round_trigger_rx) => {
+					ret = round::run_round_coordinator(app.clone(), round_input_rx, round_trigger_rx) => {
 						ret.context("error from round scheduler")
 					},
 				}

--- a/aspd/src/round/mod.rs
+++ b/aspd/src/round/mod.rs
@@ -374,7 +374,6 @@ pub async fn run_round_coordinator(
 			}
 		}
 
-		let _ = app.rounds().round_busy.write().await;
 		let round_id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() /
 			cfg.round_interval.as_secs();
 		info!("Starting round {}", round_id);

--- a/aspd/src/rpc/mod.rs
+++ b/aspd/src/rpc/mod.rs
@@ -19,16 +19,16 @@ mod convert {
 						})
 					},
 					RoundEvent::VtxoProposal {
-						id, vtxos_spec, round_tx, vtxos_signers, vtxos_agg_nonces,
+						id, vtxos_spec, round_tx, cosigners, cosign_agg_nonces,
 					} => {
 						rpc::round_event::Event::VtxoProposal(rpc::VtxoProposal {
 							round_id: id,
 							vtxos_spec: vtxos_spec.encode(),
 							round_tx: bitcoin::consensus::serialize(&round_tx),
-							vtxos_signers: vtxos_signers.into_iter()
+							vtxos_signers: cosigners.into_iter()
 								.map(|k| k.serialize().to_vec())
 								.collect(),
-							vtxos_agg_nonces: vtxos_agg_nonces.into_iter()
+							vtxos_agg_nonces: cosign_agg_nonces.into_iter()
 								.map(|n| n.serialize().to_vec())
 								.collect(),
 						})

--- a/aspd/src/rpc/mod.rs
+++ b/aspd/src/rpc/mod.rs
@@ -3,3 +3,60 @@ mod aspd;
 pub use self::aspd::*;
 pub use self::aspd::ark_service_server::{ArkService, ArkServiceServer};
 pub use self::aspd::admin_service_server::{AdminService, AdminServiceServer};
+
+mod convert {
+	use crate::rpc;
+	use crate::round::RoundEvent;
+
+	impl From<RoundEvent> for rpc::RoundEvent {
+		fn from(e: RoundEvent) -> Self {
+			rpc::RoundEvent {
+				event: Some(match e {
+					RoundEvent::Start { id, offboard_feerate } => {
+						rpc::round_event::Event::Start(rpc::RoundStart {
+							round_id: id,
+							offboard_feerate_sat_vkb: offboard_feerate.to_sat_per_kwu() * 4,
+						})
+					},
+					RoundEvent::VtxoProposal {
+						id, vtxos_spec, round_tx, vtxos_signers, vtxos_agg_nonces,
+					} => {
+						rpc::round_event::Event::VtxoProposal(rpc::VtxoProposal {
+							round_id: id,
+							vtxos_spec: vtxos_spec.encode(),
+							round_tx: bitcoin::consensus::serialize(&round_tx),
+							vtxos_signers: vtxos_signers.into_iter()
+								.map(|k| k.serialize().to_vec())
+								.collect(),
+							vtxos_agg_nonces: vtxos_agg_nonces.into_iter()
+								.map(|n| n.serialize().to_vec())
+								.collect(),
+						})
+					},
+					RoundEvent::RoundProposal { id, vtxos, round_tx, forfeit_nonces } => {
+						rpc::round_event::Event::RoundProposal(rpc::RoundProposal {
+							round_id: id,
+							signed_vtxos: vtxos.encode(),
+							round_tx: bitcoin::consensus::serialize(&round_tx),
+							forfeit_nonces: forfeit_nonces.into_iter().map(|(id, nonces)| {
+								rpc::ForfeitNonces {
+									input_vtxo_id: id.bytes().to_vec(),
+									pub_nonces: nonces.into_iter()
+										.map(|n| n.serialize().to_vec())
+										.collect(),
+								}
+							}).collect(),
+						})
+					},
+					RoundEvent::Finished { id, vtxos, round_tx } => {
+						rpc::round_event::Event::Finished(rpc::RoundFinished {
+							round_id: id,
+							signed_vtxos: vtxos.encode(),
+							round_tx: bitcoin::consensus::serialize(&round_tx),
+						})
+					},
+				})
+			}
+		}
+	}
+}

--- a/aspd/src/rpcserver.rs
+++ b/aspd/src/rpcserver.rs
@@ -13,7 +13,7 @@ use ark::{musig, OffboardRequest, VtxoRequest, Vtxo, VtxoId};
 
 use crate::App;
 use crate::rpc;
-use crate::round::{RoundEvent, RoundInput};
+use crate::round::RoundInput;
 
 macro_rules! badarg {
 	($($arg:tt)*) => {{
@@ -175,53 +175,7 @@ impl rpc::ArkService for Arc<App> {
 
 		Ok(tonic::Response::new(Box::new(stream.map(|e| {
 			let e = e.map_err(|e| internal!("broken stream: {}", e))?;
-			Ok(rpc::RoundEvent {
-				event: Some(match e {
-					RoundEvent::Start { id, offboard_feerate } => {
-						rpc::round_event::Event::Start(rpc::RoundStart {
-							round_id: id,
-							offboard_feerate_sat_vkb: offboard_feerate.to_sat_per_kwu() * 4,
-						})
-					},
-					RoundEvent::VtxoProposal {
-						id, vtxos_spec, round_tx, vtxos_signers, vtxos_agg_nonces,
-					} => {
-						rpc::round_event::Event::VtxoProposal(rpc::VtxoProposal {
-							round_id: id,
-							vtxos_spec: vtxos_spec.encode(),
-							round_tx: bitcoin::consensus::serialize(&round_tx),
-							vtxos_signers: vtxos_signers.into_iter()
-								.map(|k| k.serialize().to_vec())
-								.collect(),
-							vtxos_agg_nonces: vtxos_agg_nonces.into_iter()
-								.map(|n| n.serialize().to_vec())
-								.collect(),
-						})
-					},
-					RoundEvent::RoundProposal { id, vtxos, round_tx, forfeit_nonces } => {
-						rpc::round_event::Event::RoundProposal(rpc::RoundProposal {
-							round_id: id,
-							signed_vtxos: vtxos.encode(),
-							round_tx: bitcoin::consensus::serialize(&round_tx),
-							forfeit_nonces: forfeit_nonces.into_iter().map(|(id, nonces)| {
-								rpc::ForfeitNonces {
-									input_vtxo_id: id.bytes().to_vec(),
-									pub_nonces: nonces.into_iter()
-										.map(|n| n.serialize().to_vec())
-										.collect(),
-								}
-							}).collect(),
-						})
-					},
-					RoundEvent::Finished { id, vtxos, round_tx } => {
-						rpc::round_event::Event::Finished(rpc::RoundFinished {
-							round_id: id,
-							signed_vtxos: vtxos.encode(),
-							round_tx: bitcoin::consensus::serialize(&round_tx),
-						})
-					},
-				})
-			})
+			Ok(e.into())
 		}))))
 	}
 


### PR DESCRIPTION
This is a half-baked refactor, in prep for making round processing more concurrent and give better error messages to clients. I think this can be reviewed as is, ignoring the fact that we keep this state variable around seemingly without much purpose.