### PR TITLE
Testing framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-testing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aspd-rpc-client",
+ "bitcoin",
+ "bitcoincore-rpc",
+ "env_logger",
+ "log",
+ "portpicker",
+ "rand",
+ "regex",
+ "tokio",
+ "tonic",
+ "which 6.0.1",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,15 +473,6 @@ name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1557,6 +1566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portpicker"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,7 +1628,7 @@ dependencies = [
  "regex",
  "syn",
  "tempfile",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1694,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1706,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1895,7 +1913,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.14.0",
  "rand",
  "secp256k1-sys 0.10.0",
  "serde",
@@ -2548,6 +2566,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2749,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "zstd-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
   "aspd",
   "bark",
 
-  "sled-utils",
+  "sled-utils", "ark-testing",
 ]
 
 resolver = "2"

--- a/ark-testing/Cargo.toml
+++ b/ark-testing/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ark-testing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+aspd-rpc-client = { path = "../aspd-rpc-client" }
+anyhow.workspace= true
+bitcoin.workspace = true
+bitcoincore-rpc = "0.19.0"
+env_logger.workspace = true
+log.workspace = true
+portpicker = "0.1.1"
+rand.workspace = true
+regex = "1.10.5"
+tokio.workspace = true
+tonic.workspace = true
+which = "6.0.1"

--- a/ark-testing/src/bark.rs
+++ b/ark-testing/src/bark.rs
@@ -1,0 +1,194 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::io::prelude::*;
+use std::fs;
+use std::ffi::OsStr;
+use std::env;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use bitcoin::{
+	address::{Address, NetworkUnchecked},
+	amount::Amount};
+use tokio::process::Command as TokioCommand;
+use which::which;
+
+use crate::constants::env::BARK_EXEC;
+
+#[derive(Debug, Clone)]
+struct BarkCommand {
+	exe_path: PathBuf,
+	args: Vec<String>
+}
+
+impl BarkCommand {
+
+	pub fn new() -> anyhow::Result<Self> {
+		match env::var(BARK_EXEC) {
+			Ok(aspd_exec) => {
+				Ok(BarkCommand {
+					exe_path: which(aspd_exec)?,
+					args: vec![]}
+				)
+			},
+			Err(env::VarError::NotPresent) => {
+				Ok(BarkCommand {
+					exe_path: which("cargo")?,
+					args: ["run", "--package", "bark-client", "--"].iter().map(|x| x.to_string()).collect()
+				})
+			},
+			Err(_) => anyhow::bail!("Failed to read BARK_EXEC"),
+		}
+	}
+
+	pub fn arg<S>(&mut self, arg: S) -> &mut Self
+		where S: AsRef<OsStr> {
+			let osstr = arg.as_ref().to_str().unwrap().to_owned();
+
+			self.args.push(osstr);
+			self
+	}
+
+	pub fn args<I,S>(&mut self, args: I) -> &mut Self
+		where
+		I: IntoIterator<Item = S>,
+		S: AsRef<OsStr>,
+	{
+		for arg in args {
+			self.arg(arg.as_ref());
+		}
+		self
+	}
+
+	pub fn tokio(&self) -> TokioCommand {
+		let mut cmd = TokioCommand::new(self.exe_path.clone());
+		cmd.args(self.args.clone());
+		cmd
+	}
+}
+
+impl std::fmt::Display for BarkCommand {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?} {}", self.exe_path, self.args.join(" "))
+	}
+
+}
+
+pub struct Bark {
+	name: String,
+	config: BarkConfig,
+	counter: AtomicUsize,
+}
+pub struct BarkConfig {
+	pub datadir: PathBuf,
+	pub asp_url: String,
+	pub network: String,
+	pub bitcoind_url: String,
+	pub bitcoind_cookie: PathBuf
+}
+
+impl BarkConfig {
+
+	pub async fn create(self, name: impl AsRef<str>) -> anyhow::Result<Bark> {
+
+		let output = BarkCommand::new()?
+			.arg("create")
+			.arg("--datadir")
+			.arg(&self.datadir)
+			.arg("--asp")
+			.arg(&self.asp_url)
+			.arg(format!("--{}", self.network))
+			.arg("--bitcoind-cookie")
+			.arg(&self.bitcoind_cookie)
+			.arg("--bitcoind")
+			.arg(&self.bitcoind_url)
+			.tokio()
+			.output()
+			.await?;
+
+		if !output.status.success() {
+			let stdout = String::from_utf8(output.stdout)?;
+			let stderr = String::from_utf8(output.stderr)?;
+
+			error!("{}", stderr);
+			error!("{}", stdout);
+
+			anyhow::bail!("Failed to create {}", name.as_ref());
+		}
+
+		Ok(Bark {
+			name: name.as_ref().to_string(),
+			config: self,
+			counter: AtomicUsize::new(0)
+		})
+	}
+}
+
+impl Bark {
+
+	pub fn name(&self) -> &str {
+		&self.name
+	}
+
+	pub async fn get_address(&self) -> anyhow::Result<Address> {
+		let address_string = self.run(["get-address"]).await?.trim().to_string();
+		let address_unchecked = Address::<NetworkUnchecked>::from_str(&address_string)?;
+		Ok(address_unchecked.assume_checked())
+	}
+
+	pub async fn get_vtxo_pubkey(&self) -> anyhow::Result<String> {
+		Ok(self.run(["get-vtxo-pubkey"]).await?)
+	}
+
+	pub async fn send_round(&self, destination: String, amount: Amount) -> anyhow::Result<()> {
+		let amount = amount.to_string();
+		self.run(["send-round", &destination, &amount, "--verbose"]).await?;
+		Ok(())
+	}
+
+	pub async fn onboard(&self, amount: Amount) -> anyhow::Result<()> {
+		info!("{}: Onboard {}", self.name, amount);
+
+		self.run(["onboard", &amount.to_string()]).await?;
+		Ok(())
+	}
+
+	pub async fn run<I,S>(&self, args: I) -> anyhow::Result<String>
+		where I: IntoIterator<Item = S>, S : AsRef<str>
+	{
+		let args: Vec<String>  = args.into_iter().map(|x| x.as_ref().to_string()).collect();
+
+		let mut command = BarkCommand::new()?;
+		command
+			.arg("--datadir")
+			.arg(&self.config.datadir)
+			.args(args);
+
+		let output = command
+			.tokio()
+			.output()
+			.await?;
+
+		// Write logs to disk
+		// Create a folder for each command
+		let count = self.counter.fetch_add(1, Ordering::Relaxed);
+		let folder_name = self.config.datadir.join("cmd").join(count.to_string());
+		fs::create_dir_all(&folder_name)?;
+
+		let mut cmd_file = fs::File::create(folder_name.join("cmd"))?;
+		write!(cmd_file, "{}", command)?;
+
+		let mut stderr_file = fs::File::create(folder_name.join("stderr.log"))?;
+		writeln!(stderr_file, "{}", String::from_utf8(output.stderr)?)?;
+
+		let mut stdout_file = fs::File::create(folder_name.join("stdout.log"))?;
+		let stdout_str = String::from_utf8(output.stdout)?;
+		writeln!(stdout_file, "{}", stdout_str)?;
+
+		if output.status.success() {
+			return Ok(stdout_str.trim().to_string())
+		}
+		else {
+			anyhow::bail!("Failed to execute {:?}", command)
+		}
+	}
+}

--- a/ark-testing/src/constants.rs
+++ b/ark-testing/src/constants.rs
@@ -1,0 +1,6 @@
+pub mod env {
+	pub const TEST_LEAVE_INTACT : &str = "TEST_LEAVE_INTACT";
+	pub const BITCOIND_EXEC: &str = "BITCOIND_EXEC";
+	pub const BARK_EXEC: &str = "BARK_EXE";
+	pub const ASPD_EXEC: &str = "ASPD_EXE";
+}

--- a/ark-testing/src/context.rs
+++ b/ark-testing/src/context.rs
@@ -1,0 +1,124 @@
+use std::path::PathBuf;
+use std::fs;
+
+use crate::util::random_string;
+use crate::constants;
+use crate::daemon::bitcoind::bitcoind_exe_path;
+use crate::daemon::log::FileLogger;
+use crate::{AspD, AspDConfig, BitcoinD, BitcoinDConfig, Bark, BarkConfig};
+
+pub struct TestContext {
+	#[allow(dead_code)]
+	pub name: String,
+	pub datadir: PathBuf
+}
+
+impl TestContext {
+	pub fn new(name: impl AsRef<str>, base_path: PathBuf) -> Self {
+		fs::create_dir_all(base_path.clone()).unwrap();
+		crate::util::init_logging().expect("Logging can be initialized");
+		TestContext { name: name.as_ref().to_string(), datadir: base_path}
+	}
+
+	pub fn generate() -> Self {
+		let name = random_string();
+		let datadir = ["/tmp/ark-testing/", &name].iter().collect();
+		Self::new(name, datadir)
+	}
+
+	pub async fn bitcoind(&self, name: impl AsRef<str>) -> anyhow::Result<BitcoinD> {
+		let bitcoind_exe = bitcoind_exe_path()?;
+
+		let datadir = self.datadir.join(name.as_ref());
+		let config = BitcoinDConfig {
+			datadir,
+			txindex: true,
+			network: String::from("regtest"),
+			..BitcoinDConfig::default()
+		};
+
+		let mut bitcoind = BitcoinD::new(name.as_ref().to_string(), bitcoind_exe, config);
+		bitcoind.start().await?;
+
+		Ok(bitcoind)
+	}
+
+	pub async fn aspd(&self, name: impl AsRef<str>, bitcoind: &BitcoinD) -> anyhow::Result<AspD> {
+
+		let datadir = self.datadir.join(name.as_ref());
+
+		let stdout_logger = FileLogger::new(datadir.join("stdout.log"));
+		let stderr_logger = FileLogger::new(datadir.join("stderr.log"));
+
+		let cfg = AspDConfig {
+			datadir,
+			bitcoind_url: bitcoind.bitcoind_url(),
+			bitcoind_cookie: bitcoind.bitcoind_cookie()
+		};
+
+		let mut aspd = AspD::new(name, cfg);
+
+
+
+		aspd.add_stdout_handler(stdout_logger)?;
+		aspd.add_stderr_handler(stderr_logger)?;
+
+		aspd.start().await?;
+
+		Ok(aspd)
+	}
+
+
+	pub async fn bark(&self, name: impl AsRef<str>, bitcoind: &BitcoinD, aspd: &AspD) -> anyhow::Result<Bark> {
+		let datadir = self.datadir.join(name.as_ref());
+		let asp_url = aspd.asp_url()?;
+
+		let cfg = BarkConfig {
+			datadir,
+			asp_url,
+			bitcoind_url: bitcoind.bitcoind_url(),
+			bitcoind_cookie: bitcoind.bitcoind_cookie(),
+			network: String::from("regtest")};
+		let bark = cfg.create(name).await?;
+
+		Ok(bark)
+	}
+}
+
+impl Drop for TestContext {
+	fn drop(&mut self) {
+		// Remove the data-directory
+		// If the user has set `LEAVE_INTACT` we don't delete any
+		// test-data.
+
+		if std::env::var(constants::env::TEST_LEAVE_INTACT).is_ok() {
+			log::info!("Textcontext: Leave intact at {:?}", self.datadir);
+			return
+		}
+		if self.datadir.exists() {
+			log::trace!("Testcontext: Clean up datadir at {:?}. Set `TEST_LEAVE_INTACT` if you want to see the content", self.datadir);
+			std::fs::remove_dir_all(self.datadir.clone()).unwrap();
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn context_creates_and_deletes_datadir() {
+		let context = TestContext::generate();
+		let base_path = context.datadir.clone();
+
+		// The base-path is created
+		assert!(context.datadir.exists());
+		drop(context);
+
+		// The test cleans up after itself
+		match std::env::var(constants::env::TEST_LEAVE_INTACT) {
+			Ok(_) => assert!(base_path.exists()),
+			Err(_) => assert!(!base_path.exists())
+		}
+	}
+}

--- a/ark-testing/src/daemon/aspd.rs
+++ b/ark-testing/src/daemon/aspd.rs
@@ -1,0 +1,207 @@
+use std::time::Duration;
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use anyhow::Context;
+use bitcoin::address::{Address, NetworkUnchecked, NetworkChecked};
+
+use which::which;
+
+use aspd_rpc_client::{AdminServiceClient as AspDAdminClient, ArkServiceClient as AspDClient};
+use aspd_rpc_client::Empty;
+
+use crate::{Daemon, DaemonHelper};
+use crate::constants::env::ASPD_EXEC;
+
+pub fn get_base_cmd() -> anyhow::Result<Command> {
+	match env::var(ASPD_EXEC) {
+		Ok(aspd_exec) => {
+			let aspd_exe = which(aspd_exec).expect("Failed to find aspd_exec");
+			Ok(Command::new(aspd_exe))
+		},
+		Err(env::VarError::NotPresent) => {
+			let mut cmd = Command::new("cargo");
+			cmd
+				.args(&["run", "--package", "bark-aspd", "--"]);
+			Ok(cmd)
+		},
+		Err(_) => panic!("Failed to read ASPD_EXEC"),
+	}
+}
+pub type AspD = Daemon<AspDHelper>;
+
+pub struct AspDHelper {
+	name : String,
+	state: AspDState,
+	config: AspDConfig
+}
+
+pub struct AspDConfig {
+	pub datadir: PathBuf,
+	pub bitcoind_url : String,
+	pub bitcoind_cookie: PathBuf
+}
+
+#[derive(Default)]
+struct AspDState {
+	public_grpc_address: Option<String>,
+	admin_grpc_address: Option<String>,
+}
+
+impl AspD {
+
+	pub fn new(name: impl AsRef<str>, config: AspDConfig) -> Self {
+		let helper = AspDHelper {
+			name: name.as_ref().to_string(),
+			config,
+			state: AspDState::default()
+		};
+
+		Daemon::wrap(helper)
+	}
+
+	pub fn asp_url(&self) -> anyhow::Result<String> {
+		self.inner.asp_url()
+	}
+
+	pub async fn get_admin_client(&self) -> anyhow::Result<AspDAdminClient<tonic::transport::Channel>> {
+		self.inner.get_admin_client().await
+	}
+
+	pub async fn get_public_client(&self) -> anyhow::Result<AspDClient<tonic::transport::Channel>> {
+		self.inner.get_public_client().await
+	}
+
+	pub async fn get_funding_address(&self) -> anyhow::Result<Address> {
+		let mut admin_client = self.get_admin_client().await?;
+		let response = admin_client.wallet_status(Empty {}).await?.into_inner();
+		let address: Address<NetworkChecked> = response.address.parse::<Address<NetworkUnchecked>>()?.assume_checked();
+		Ok(address)
+
+	}
+}
+
+impl DaemonHelper for AspDHelper {
+
+	fn name(&self) -> &str {
+		&self.name
+	}
+
+	async fn make_reservations(&mut self) -> anyhow::Result<()> {
+		let public_grpc_port = portpicker::pick_unused_port().expect("No ports free");
+		let admin_grpc_port = portpicker::pick_unused_port().expect("No ports free");
+
+		let public_grpc_address = format!("0.0.0.0:{}", public_grpc_port);
+		let admin_grpc_address = format!("127.0.0.1:{}", admin_grpc_port);
+
+		let mut base_cmd = get_base_cmd()?;
+
+		let datadir = self.config.datadir.clone();
+		let pgrpc = public_grpc_address.clone();
+		let agrpc = admin_grpc_address.clone();
+
+		let output : Output = tokio::task::spawn_blocking(move || base_cmd
+			.arg("--datadir")
+			.arg(datadir)
+			.arg("set-config")
+			.arg("--public-rpc-address")
+			.arg(pgrpc)
+			.arg("--admin-rpc-address")
+			.arg(agrpc)
+			.output())
+			.await??;
+
+		if ! output.status.success() {
+			let stderr = String::from_utf8(output.stderr)?;
+			error!("{}", stderr);
+			anyhow::bail!("Failed to configure ports for arkd-1");
+		};
+
+		self.state.public_grpc_address = Some(public_grpc_address);
+		self.state.admin_grpc_address = Some(admin_grpc_address);
+
+		Ok(())
+	}
+
+	async fn prepare(&self) -> anyhow::Result<()> {
+		let mut base_cmd = get_base_cmd()?;
+
+		let datadir = self.config.datadir.clone();
+		let bd_url = self.config.bitcoind_url.clone();
+		let bd_cookie = self.config.bitcoind_cookie.clone();
+		let output : Output = tokio::task::spawn_blocking(move || base_cmd
+			.arg("--datadir")
+			.arg(datadir)
+			.arg("create")
+			.arg("--bitcoind-url")
+			.arg(bd_url)
+			.arg("--bitcoind-cookie")
+			.arg(bd_cookie)
+			.arg("--network")
+			.arg("regtest")
+			.output()).await??;
+
+		if output.status.success() {
+			Ok(())
+		} else {
+			let stderr = String::from_utf8(output.stderr)?;
+			error!("{}", stderr);
+			anyhow::bail!("Failed to start arkd-1");
+		}
+	}
+
+	async fn get_command(&self) -> anyhow::Result<Command> {
+
+		let mut base_cmd = get_base_cmd()?;
+		base_cmd
+			.arg("--datadir")
+			.arg(&self.config.datadir)
+			.arg("start");
+
+		Ok(base_cmd)
+	}
+
+	async fn wait_for_init(&self) -> anyhow::Result<()> {
+
+		while !self.is_ready().await {
+			tokio::time::sleep(Duration::from_millis(100)).await;
+		}
+		Ok(())
+	}
+}
+
+impl AspDHelper {
+
+	async fn is_ready(&self) -> bool {
+		return self.admin_grpc_is_ready().await && self.public_grpc_is_ready().await
+	}
+
+	async fn admin_grpc_is_ready(&self) -> bool {
+		match self.get_admin_client().await {
+				Ok(mut client) => client.wallet_status(Empty {}).await.is_ok(),
+				Err(_) => false
+			}
+	}
+
+	async fn public_grpc_is_ready(&self) -> bool {
+		match self.get_admin_client().await {
+				Ok(mut client) => client.wallet_status(Empty {}).await.is_ok(),
+				Err(_) => false
+			}
+	}
+
+	pub fn asp_url(&self) -> anyhow::Result<String> {
+		Ok(format!("http://{}", self.state.public_grpc_address.clone().context("Is asp running")?))
+	}
+
+	pub async fn get_admin_client(&self) -> anyhow::Result<AspDAdminClient<tonic::transport::Channel>> {
+		let url = format!("http://{}", self.state.admin_grpc_address.clone().expect("The admin_grpc port is set. Is aspd running?"));
+		Ok(AspDAdminClient::connect(url).await?)
+	}
+
+	pub async fn get_public_client(&self) -> anyhow::Result<AspDClient<tonic::transport::Channel>> {
+		let url = format!("http://{}", self.state.public_grpc_address.clone().expect("The public_grpc_address port is set. Is aspd running?"));
+		Ok(AspDClient::connect(url).await?)
+	}
+}

--- a/ark-testing/src/daemon/bitcoind.rs
+++ b/ark-testing/src/daemon/bitcoind.rs
@@ -1,0 +1,193 @@
+use std::env::VarError;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::Context;
+use bitcoincore_rpc::{Client as BitcoinDClient, Auth, RpcApi};
+use which::which;
+
+use crate::{Bark, AspD};
+use crate::daemon::{Daemon, DaemonHelper};
+use crate::constants::env::BITCOIND_EXEC;
+
+use bitcoin::{
+	amount::Amount,
+	network::Network,
+	transaction::Txid};
+
+pub struct BitcoinDHelper {
+	name : String,
+	bitcoind_exec: PathBuf,
+	config: BitcoinDConfig,
+	state: BitcoinDState,
+}
+
+pub struct BitcoinDConfig {
+	pub datadir: PathBuf,
+	pub txindex: bool,
+	pub network: String,
+	pub fallback_fee: Option<f64>,
+}
+
+impl Default for BitcoinDConfig {
+
+	fn default() -> Self {
+		Self {
+			datadir: PathBuf::from("~/.bitcoin"),
+			txindex: false,
+			network: String::from("regtest"),
+			fallback_fee: Some(0.00001)
+		}
+	}
+}
+
+#[derive(Default)]
+pub struct BitcoinDState {
+	rpc_port: Option<u16>,
+	p2p_port: Option<u16>,
+}
+
+pub type BitcoinD = Daemon<BitcoinDHelper>;
+
+pub fn bitcoind_exe_path() -> anyhow::Result<PathBuf> {
+		match std::env::var(&BITCOIND_EXEC) {
+			Ok(var) => which(var).context("Failed to find binary path from `BITCOIND_EXEC`"),
+			Err(VarError::NotPresent) => which("bitcoind").context("Failed to find `bitcoind` installation"),
+			_ => anyhow::bail!("BITCOIND_EXEC is not valid unicode")
+		}
+}
+
+impl BitcoinD {
+
+	pub fn new(name: String, bitcoind_exec: PathBuf, config: BitcoinDConfig) -> Self {
+		let state = BitcoinDState::default();
+		let inner = BitcoinDHelper { name, bitcoind_exec, config, state};
+		Daemon::wrap(inner)
+	}
+
+	pub fn sync_client(&self) -> anyhow::Result<BitcoinDClient> {
+		self.inner.sync_client()
+	}
+
+	pub fn bitcoind_cookie(&self) -> PathBuf {
+		self.inner.bitcoind_cookie()
+	}
+
+	pub fn bitcoind_url(&self) -> String {
+		self.inner.bitcoind_url()
+	}
+
+	pub async fn init_wallet(&self) -> anyhow::Result<()> {
+		info!("Initialziing a wallet");
+		let client = self.sync_client()?;
+
+		match client.get_wallet_info() {
+			Ok(_) => Ok(()), // A wallet exists
+			Err(_) => {
+				let _ = client.create_wallet("", None, None, None, None)?;
+				Ok(())
+			}
+		}
+	}
+
+	pub async fn generate(&self, block_num: u64) -> anyhow::Result<()> {
+		self.init_wallet().await?;
+
+		let client = self.sync_client()?;
+		let address = client.get_new_address(None, None)?.require_network(Network::Regtest)?;
+		client.generate_to_address(block_num, &address)?;
+
+		Ok(())
+	}
+
+	pub async fn fund_aspd(&self, aspd: &AspD, amount: Amount) -> anyhow::Result<()> {
+		let address = aspd.get_funding_address().await?;
+		self.sync_client()?.send_to_address(&address, amount, None, None, None, None, None, None)?;
+		Ok(())
+	}
+
+	pub async fn fund_bark(&self, bark: &Bark, amount: Amount) -> anyhow::Result<Txid> {
+		info!("Fund {} {}", bark.name(), amount);
+		let address = bark.get_address().await?;
+		let client = self.sync_client()?;
+		let txid = client.send_to_address(&address, amount, None, None, None, None, None, None)?;
+
+		Ok(txid)
+	}
+
+}
+
+impl BitcoinDHelper {
+
+	pub fn auth(&self) -> Auth {
+			Auth::CookieFile(self.bitcoind_cookie())
+	}
+
+	pub fn bitcoind_cookie(&self) -> PathBuf {
+		let cookie = self.config.datadir
+			.join(&self.config.network)
+			.join(".cookie");
+
+		cookie
+	}
+
+	pub fn bitcoind_url(&self) -> String {
+		format!("http://127.0.0.1:{}", self.state.rpc_port.expect("A port has been picked. Is bitcoind running?"))
+	}
+
+	pub fn sync_client(&self) -> anyhow::Result<BitcoinDClient> {
+		let bitcoind_url = self.bitcoind_url();
+		let auth = self.auth();
+		let client = BitcoinDClient::new(&bitcoind_url, auth)?;
+		Ok(client)
+	}
+}
+
+impl DaemonHelper for BitcoinDHelper {
+
+	fn name(&self) -> &str {
+		&self.name
+	}
+
+	async fn make_reservations(&mut self) -> anyhow::Result<()> {
+		self.state.rpc_port = Some(portpicker::pick_unused_port().expect("A port is free"));
+		self.state.p2p_port = Some(portpicker::pick_unused_port().expect("A port is free"));
+
+		Ok(())
+	}
+	async fn prepare(&self) -> anyhow::Result<()> {
+		debug!("Creating bitcoind datadir in {:?}", self.config.datadir.clone());
+		std::fs::create_dir_all(self.config.datadir.clone())?;
+		Ok(())
+	}
+
+	async fn get_command(&self) -> anyhow::Result<Command> {
+		let mut cmd = Command::new(self.bitcoind_exec.clone());
+		cmd
+			.arg(format!("--{}", self.config.network))
+			.arg(format!("-datadir={}", self.config.datadir.display().to_string()))
+			.arg(format!("-txindex={}", self.config.txindex))
+			.arg(format!("-rpcport={}", self.state.rpc_port.expect("A port has been picked")))
+			.arg(format!("-port={}", self.state.p2p_port.expect("A port has been picked")));
+
+		match &self.config.fallback_fee {
+			Some(w) => {let _ = cmd.arg(format!("-fallbackfee={}", w));},
+			None => {}
+		}
+
+		Ok(cmd)
+	}
+
+
+	async fn wait_for_init(&self) -> anyhow::Result<()> {
+		loop {
+			if let Ok(client) = self.sync_client() {
+				if client.get_blockchain_info().is_ok(){
+					return Ok(())
+				}
+			}
+			tokio::time::sleep(Duration::from_millis(100)).await;
+		}
+	}
+}

--- a/ark-testing/src/daemon/log.rs
+++ b/ark-testing/src/daemon/log.rs
@@ -1,0 +1,40 @@
+use std::fs::{File, OpenOptions};
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+use crate::daemon::LogHandler;
+
+#[derive(Debug)]
+pub struct FileLogger {
+	path: PathBuf,
+	file: Option<File>
+}
+
+impl FileLogger {
+
+	pub fn new(path: PathBuf) -> Self {
+		Self { path, file: None }
+	}
+}
+
+impl LogHandler for FileLogger {
+
+	fn process_log(&mut self, line: &str) {
+
+		// Create the file if it doesn't exist yet
+		if self.file.is_none() {
+			let file = OpenOptions::new()
+				.create_new(true)
+				.append(true)
+				.open(&self.path).unwrap();
+			self.file = Some(file);
+		}
+
+		let file = self.file.as_mut().unwrap();
+
+		match writeln!(file, "{}", line) {
+			Ok(()) => {},
+			Err(_) => error!("Failed to write to lig-file")
+		}
+	}
+}

--- a/ark-testing/src/daemon/mod.rs
+++ b/ark-testing/src/daemon/mod.rs
@@ -1,0 +1,203 @@
+pub mod bitcoind;
+pub mod aspd;
+pub mod log;
+
+use std::future::Future;
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+pub enum DaemonState {
+	Init,
+	Starting,
+	Running,
+	Stopping,
+	Stopped,
+	Error
+}
+
+pub trait LogHandler {
+	fn process_log(&mut self, line: &str);
+}
+
+pub trait DaemonHelper {
+	fn name(&self) -> &str;
+	fn make_reservations(&mut self) -> impl Future<Output = anyhow::Result<()>> + Send;
+	fn prepare(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
+	fn get_command(&self) -> impl Future<Output = anyhow::Result<Command>> + Send;
+	fn wait_for_init(&self) -> impl Future<Output = anyhow::Result<()>> + Send;
+}
+
+pub struct Daemon<T>
+where T : DaemonHelper + Send + Sync + 'static
+{
+	inner : T,
+	daemon_state: DaemonState,
+	child: Option<Child>,
+	stdout_jh: Option<JoinHandle<()>>,
+	stderr_jh: Option<JoinHandle<()>>,
+	stdout_handler: Arc<Mutex<Vec<Box<dyn LogHandler + Send + Sync + 'static>>>>,
+	stderr_handler: Arc<Mutex<Vec<Box<dyn LogHandler + Send + Sync + 'static>>>>
+}
+
+impl<T> Daemon<T>
+where T: DaemonHelper + Send + Sync + 'static
+{
+
+	pub fn wrap(inner : T) -> Self {
+
+		Self {
+			inner,
+			daemon_state: DaemonState::Init,
+			child: None,
+			stdout_handler: Arc::new(Mutex::new(vec![])),
+			stderr_handler: Arc::new(Mutex::new(vec![])),
+			stdout_jh: None,
+			stderr_jh: None
+		}
+	}
+}
+
+impl<T> Daemon<T>
+where T : DaemonHelper + Send + Sync + 'static
+{
+
+	pub async fn start(&mut self) -> anyhow::Result<()> {
+		info!("Starting {}", self.inner.name());
+		self.daemon_state = DaemonState::Starting;
+
+		trace!("Preparing {}", self.inner.name());
+		self.inner.prepare().await?;
+
+		let retries = 3;
+		for i in 0..retries {
+			match self.try_start().await {
+				Ok(_) => {
+					info!("Started {}", self.inner.name());
+					self.daemon_state = DaemonState::Running;
+					return Ok(());
+				},
+				Err(_) => {
+					warn!("Failed attempt to start {}. This was attempt {} of {}", self.inner.name(), i, retries);
+				}
+			}
+		}
+
+		error!("Failed to start {}", self.inner.name());
+		self.daemon_state = DaemonState::Error;
+		anyhow::bail!("Failed to launch daemon");
+	}
+
+	pub async fn try_start(&mut self) -> anyhow::Result<()> {
+		self.inner.make_reservations().await?;
+
+		let mut cmd = self
+			.inner
+			.get_command()
+			.await?;
+
+		cmd
+			.stdout(Stdio::piped())
+			.stderr(Stdio::piped());
+
+		trace!("{}: Trying to spawn {:?}", self.inner.name(), cmd);
+		let mut child = cmd.spawn()?;
+
+		let stdout = child.stdout.take().unwrap();
+		let stderr = child.stderr.take().unwrap();
+		let stdout_log = self.stdout_handler.clone();
+		let stderr_log = self.stderr_handler.clone();
+
+		self.stdout_jh = Some(std::thread::spawn(move || {
+			let reader = BufReader::new(stdout);
+			for line in reader.lines() {
+				let line = line.unwrap();
+				for handler in stdout_log.lock().unwrap().iter_mut() {
+					handler.process_log(&line)
+				}
+			}
+		}));
+
+		self.stderr_jh = Some(std::thread::spawn(move || {
+			let reader = BufReader::new(stderr);
+			for line in reader.lines() {
+				let line = line.unwrap();
+				for handler in stderr_log.lock().unwrap().iter_mut() {
+					handler.process_log(&line)
+				}
+			}
+		}));
+
+		self.child = Some(child);
+
+		// TODO: Provide a time-out here
+		// TODO: Check if the child has finished after every await
+		self.inner.wait_for_init().await?;
+
+		Ok(())
+	}
+
+	pub async fn stop(&mut self) -> anyhow::Result<()> {
+		trace!("Stopping {}", self.inner.name());
+		self.daemon_state = DaemonState::Stopping;
+
+		match self.child.take() {
+			Some(mut child) => tokio::task::spawn_blocking(move || child.kill()).await?,
+			None => anyhow::bail!("Failed to stop daemon because there is no child. Was it running?")
+		}?;
+
+
+		info!("Stopped {}", self.inner.name());
+		self.daemon_state = DaemonState::Stopped;
+		Ok(())
+	}
+
+	pub async fn join(&mut self) -> anyhow::Result<()> {
+
+		match self.child.take() {
+			Some(mut child) => { tokio::task::spawn_blocking(move || child.wait())}.await?,
+			None => anyhow::bail!("Failed to wait for daemon to complete. Was it running?")
+		}?;
+
+		Ok(())
+	}
+
+	pub fn add_stdout_handler<L : LogHandler + Send + Sync + 'static>(&mut self, log_handler: L) -> anyhow::Result<()> {
+		trace!("{}: Added logger", self.inner.name());
+		let mut handlers = self.stdout_handler.lock().unwrap();
+		handlers.push(Box::new(log_handler));
+		Ok(())
+	}
+
+
+	pub fn add_stderr_handler<L : LogHandler + Send + Sync + 'static>(&mut self, log_handler: L) -> anyhow::Result<()> {
+		trace!("{}: Added logger", self.inner.name());
+		let mut handlers = self.stderr_handler.lock().unwrap();
+		handlers.push(Box::new(log_handler));
+		Ok(())
+	}
+}
+
+impl<T> Drop for Daemon<T>
+where T: DaemonHelper + Send + Sync + 'static
+{
+
+	fn drop(&mut self) {
+
+		match self.child.take() {
+			Some(mut c) => { let _ = c.kill(); },
+			None => {}
+		}
+
+		match self.stdout_jh.take() {
+			Some(jh) => { let _ = jh.join(); },
+			None => {}
+		}
+
+		match self.stderr_jh.take() {
+			Some(jh) => { let _ = jh.join(); },
+			None => {}
+		}
+	}
+}

--- a/ark-testing/src/lib.rs
+++ b/ark-testing/src/lib.rs
@@ -1,0 +1,14 @@
+#[macro_use]
+extern crate log;
+
+pub mod context;
+pub mod constants;
+pub mod daemon;
+pub mod util;
+pub mod bark;
+
+pub use context::TestContext;
+pub use daemon::{Daemon, DaemonHelper};
+pub use daemon::bitcoind::{BitcoinD, BitcoinDConfig};
+pub use daemon::aspd::{AspD, AspDConfig};
+pub use bark::{Bark, BarkConfig};

--- a/ark-testing/src/util.rs
+++ b/ark-testing/src/util.rs
@@ -1,0 +1,21 @@
+use rand::RngCore;
+
+pub fn random_string() -> String {
+	// Generate a few random bytes and base58 encode them
+	// The entropy should be sufficient to generate unique test-names
+	let mut entropy :[u8; 8] = [0; 8];
+	rand::thread_rng().fill_bytes(&mut entropy);
+	bitcoin::base58::encode(&entropy)
+}
+
+pub fn init_logging() -> anyhow::Result<()> {
+	// We ignore the output
+	// An error is returned if the logger is initiated twice
+	// Note, that every test tries to initiate the logger
+	let _ =
+		env_logger::Builder::from_env(
+			env_logger::Env::default().default_filter_or("trace"))
+		.is_test(true)
+		.try_init();
+	Ok(())
+}

--- a/ark-testing/tests/aspd.rs
+++ b/ark-testing/tests/aspd.rs
@@ -1,0 +1,49 @@
+extern crate tokio;
+
+use std::time::Duration;
+
+use tokio::process::Command;
+
+use ark_testing::TestContext;
+use aspd_rpc_client::Empty;
+
+use bitcoin::amount::Amount;
+
+#[tokio::test]
+async fn check_aspd_version() {
+	let output = Command::new("cargo")
+		.arg("run")
+		.arg("--package")
+		.arg("bark-aspd")
+		.arg("--")
+		.arg("--version")
+		.kill_on_drop(true)
+		.output()
+		.await
+		.expect("Failed to spawn process and capture output");
+
+	let stdout = String::from_utf8(output.stdout).expect("Output is valid utf-8");
+	assert!(stdout.starts_with("bark-aspd"))
+}
+
+#[tokio::test]
+async fn fund_asp() {
+	let context = TestContext::generate();
+	let bitcoind = context.bitcoind("bitcoind-1").await.expect("bitcoind-1 started");
+	bitcoind.generate(106).await.unwrap();
+	let aspd = context.aspd("aspd-1", &bitcoind).await.expect("arkd-1 started");
+	let mut admin_client = aspd.get_admin_client().await.expect("Can conect to the admin-client");
+
+
+	// Query the wallet balance of the asp
+	let response  = admin_client.wallet_status(Empty {}).await.expect("Get response").into_inner();
+	assert_eq!(response.balance, 0);
+
+	// Fund the aspd
+	bitcoind.fund_aspd(&aspd, Amount::from_int_btc(10)).await.unwrap();
+	tokio::time::sleep(Duration::from_secs(5)).await;
+
+	// Confirm that the balance is updated
+	let response  = admin_client.wallet_status(Empty {}).await.expect("Get response").into_inner();
+	assert!(response.balance > 0);
+}

--- a/ark-testing/tests/bark.rs
+++ b/ark-testing/tests/bark.rs
@@ -1,0 +1,110 @@
+use ark_testing::context::TestContext;
+
+use bitcoincore_rpc::bitcoin::amount::Amount;
+
+#[tokio::test]
+async fn bark_version() {
+	let ctx = TestContext::generate();
+	let bitcoind = ctx.bitcoind("bitcoind-1").await.unwrap();
+	let aspd = ctx.aspd("aspd-1", &bitcoind).await.unwrap();
+
+	//
+	let bark = ctx.bark("bark-1".to_string(), &bitcoind, &aspd).await.unwrap();
+	let result = bark.run(&[&"--version"]).await.unwrap();
+
+	assert!(result.starts_with("bark-client"));
+}
+
+#[tokio::test]
+async fn onboard_bark() {
+	let ctx = TestContext::generate();
+	let bitcoind = ctx.bitcoind("bitcoind-1").await.unwrap();
+	let aspd = ctx.aspd("aspd-1", &bitcoind).await.unwrap();
+	let bark = ctx.bark("bark-1".to_string(), &bitcoind, &aspd).await.unwrap();
+
+	// Generate initial funds
+	bitcoind.generate(101).await.unwrap();
+
+	// Get the bark-address and fund it
+	bitcoind.fund_bark(&bark, Amount::from_sat(100_000)).await.unwrap();
+	bark.onboard(Amount::from_sat(90_000)).await.unwrap();
+
+	// TODO: Verify the onboarded balance
+	// The current cli only provides logs in stdout. This is to annoying
+	let _: String = bark.run(["balance"]).await.unwrap();
+}
+
+#[tokio::test]
+async fn multiple_round_payments() {
+	// Initialize the test
+	let ctx = TestContext::generate();
+	let bitcoind = ctx.bitcoind("bitcoind-1").await.unwrap();
+	let aspd = ctx.aspd("aspd-1", &bitcoind).await.unwrap();
+
+	// Fund the asp
+	bitcoind.generate(106).await.unwrap();
+	bitcoind.fund_aspd(&aspd, Amount::from_int_btc(10)).await.unwrap();
+
+	// Create a few clients
+	let bark_1 = ctx.bark("bark_1".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_2 = ctx.bark("bark_2".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_3 = ctx.bark("bark_3".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_4 = ctx.bark("bark_4".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_5 = ctx.bark("bark_5".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_6 = ctx.bark("bark_6".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_7 = ctx.bark("bark_7".to_string(), &bitcoind, &aspd).await.unwrap();
+	let bark_8 = ctx.bark("bark_8".to_string(), &bitcoind, &aspd).await.unwrap();
+
+	// Provide onchain funds
+	tokio::try_join!(
+		bitcoind.fund_bark(&bark_1, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_2, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_3, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_4, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_5, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_6, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_7, Amount::from_sat(90_000)),
+		bitcoind.fund_bark(&bark_8, Amount::from_sat(90_000)),
+	).unwrap();
+
+	// Onboard all the clients
+	tokio::try_join!(
+		bark_1.onboard(Amount::from_sat(80_000)),
+		bark_2.onboard(Amount::from_sat(80_000)),
+		bark_3.onboard(Amount::from_sat(80_000)),
+		bark_4.onboard(Amount::from_sat(80_000)),
+		bark_5.onboard(Amount::from_sat(80_000)),
+		bark_6.onboard(Amount::from_sat(80_000)),
+		bark_7.onboard(Amount::from_sat(80_000)),
+		bark_8.onboard(Amount::from_sat(80_000)),
+	).unwrap();
+
+		// Get all the vtxo pubkeys
+	let (a1, a2, a3, a4, a5, a6, a7, a8) =
+		tokio::try_join!(
+			bark_1.get_vtxo_pubkey(),
+			bark_2.get_vtxo_pubkey(),
+			bark_3.get_vtxo_pubkey(),
+			bark_4.get_vtxo_pubkey(),
+			bark_5.get_vtxo_pubkey(),
+			bark_6.get_vtxo_pubkey(),
+			bark_7.get_vtxo_pubkey(),
+			bark_8.get_vtxo_pubkey(),
+	).unwrap();
+
+	// Perform send_round
+	tokio::try_join!(
+		bark_1.send_round(a2, Amount::from_sat(100)),
+		bark_2.send_round(a3, Amount::from_sat(200)),
+		bark_3.send_round(a4, Amount::from_sat(300)),
+		bark_4.send_round(a5, Amount::from_sat(400)),
+		bark_5.send_round(a6, Amount::from_sat(500)),
+		bark_6.send_round(a7, Amount::from_sat(600)),
+		bark_7.send_round(a8, Amount::from_sat(700)),
+		bark_8.send_round(a1, Amount::from_sat(800)),
+	).unwrap();
+
+}
+
+// Make every client do a send_round payment
+

--- a/ark-testing/tests/bitcoind.rs
+++ b/ark-testing/tests/bitcoind.rs
@@ -1,0 +1,33 @@
+extern crate bitcoincore_rpc;
+
+use bitcoincore_rpc::RpcApi;
+use ark_testing::context::TestContext;
+
+#[tokio::test]
+async fn start_bitcoind()  {
+	let context = TestContext::generate();
+	let bitcoind = context.bitcoind("bitcoind-1").await.expect("bitcoind can be initialized");
+
+	let client = bitcoind.sync_client().expect("Client can be created");
+	let info = client.get_blockchain_info().expect("Get info about the blockchain");
+	assert_eq!(info.chain.to_string(), "regtest");
+}
+
+#[tokio::test]
+async fn fund_bitcoind() {
+	let context = TestContext::generate();
+	let bitcoind = context.bitcoind("bitcoind-1").await.expect("bitcoind can be initialized");
+
+	// We can initialize the wallet twice
+	bitcoind.init_wallet().await.unwrap();
+	bitcoind.init_wallet().await.unwrap();
+
+	// We can fund the wallet
+	bitcoind.generate(101).await.unwrap();
+
+	// Check the balance
+	let client = bitcoind.sync_client().unwrap();
+	let amount = client.get_balance(Some(6), None).unwrap();
+	assert!(amount.to_sat() > 100_000_000);
+}
+


### PR DESCRIPTION
Introduces a testing framework that works with async rust.

The design goals are
- **debug**: Leave a lot of traces. All processes write their log to files which are easy to inspect.
- **swap** easily swap `aspd` or `bark` when running the tests. Great for testing backward compatibility
- **ergonomics**: Writing tests should be ergonomic

The framework als manages to reproduce a bug.
See`tests::bark::multiple_round_payments` which makes the `asp` panic