### PR TITLE
Change directory structure for test-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ debug/
 target/
 .direnv/
 rustdocs/
+test/

--- a/ark-testing/src/constants.rs
+++ b/ark-testing/src/constants.rs
@@ -1,5 +1,5 @@
 pub mod env {
-	pub const TEST_LEAVE_INTACT : &str = "TEST_LEAVE_INTACT";
+	pub const TEST_DIRECTORY: &str = "TEST_DIRECTORY";
 	pub const BITCOIND_EXEC: &str = "BITCOIND_EXEC";
 	pub const BARK_EXEC: &str = "BARK_EXE";
 	pub const ASPD_EXEC: &str = "ASPD_EXE";

--- a/ark-testing/tests/aspd.rs
+++ b/ark-testing/tests/aspd.rs
@@ -28,7 +28,7 @@ async fn check_aspd_version() {
 
 #[tokio::test]
 async fn fund_asp() {
-	let context = TestContext::generate();
+	let context = TestContext::new("aspd/fund_aspd");
 	let bitcoind = context.bitcoind("bitcoind-1").await.expect("bitcoind-1 started");
 	bitcoind.generate(106).await.unwrap();
 	let aspd = context.aspd("aspd-1", &bitcoind).await.expect("arkd-1 started");

--- a/ark-testing/tests/bark.rs
+++ b/ark-testing/tests/bark.rs
@@ -4,7 +4,7 @@ use bitcoincore_rpc::bitcoin::amount::Amount;
 
 #[tokio::test]
 async fn bark_version() {
-	let ctx = TestContext::generate();
+	let ctx = TestContext::new("bark_version");
 	let bitcoind = ctx.bitcoind("bitcoind-1").await.unwrap();
 	let aspd = ctx.aspd("aspd-1", &bitcoind).await.unwrap();
 
@@ -17,7 +17,7 @@ async fn bark_version() {
 
 #[tokio::test]
 async fn onboard_bark() {
-	let ctx = TestContext::generate();
+	let ctx = TestContext::new("bark/onboard_bark");
 	let bitcoind = ctx.bitcoind("bitcoind-1").await.unwrap();
 	let aspd = ctx.aspd("aspd-1", &bitcoind).await.unwrap();
 	let bark = ctx.bark("bark-1".to_string(), &bitcoind, &aspd).await.unwrap();
@@ -37,7 +37,7 @@ async fn onboard_bark() {
 #[tokio::test]
 async fn multiple_round_payments() {
 	// Initialize the test
-	let ctx = TestContext::generate();
+	let ctx = TestContext::new("bark/multiple_round_payments");
 	let bitcoind = ctx.bitcoind("bitcoind-1").await.unwrap();
 	let aspd = ctx.aspd("aspd-1", &bitcoind).await.unwrap();
 

--- a/ark-testing/tests/bitcoind.rs
+++ b/ark-testing/tests/bitcoind.rs
@@ -5,7 +5,7 @@ use ark_testing::context::TestContext;
 
 #[tokio::test]
 async fn start_bitcoind()  {
-	let context = TestContext::generate();
+	let context = TestContext::new("bitcoind/start_bitcoind");
 	let bitcoind = context.bitcoind("bitcoind-1").await.expect("bitcoind can be initialized");
 
 	let client = bitcoind.sync_client().expect("Client can be created");
@@ -15,7 +15,7 @@ async fn start_bitcoind()  {
 
 #[tokio::test]
 async fn fund_bitcoind() {
-	let context = TestContext::generate();
+	let context = TestContext::new("bitcoind/fund_bitcoind");
 	let bitcoind = context.bitcoind("bitcoind-1").await.expect("bitcoind can be initialized");
 
 	// We can initialize the wallet twice


### PR DESCRIPTION
Previously all test-data was stored in the `/tmp`-directory. I have made the behavior configurable and changed the default to the `./test`-folder in the workspace root.

I've also modified how `TestContext` works. The test-data is left intact by default. It is also easier to find the test-data because we don't use randmly generated folder names by default.

The only downside is that weird things might happen if you do multiple evocations of `cargo test` concurrently. I'll assume nobody will be doing that.