### PR TITLE
Rename `arkd` to `aspd` in protobuf file

### DIFF
--- a/aspd-rpc-client/src/aspd.rs
+++ b/aspd-rpc-client/src/aspd.rs
@@ -336,11 +336,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/GetArkInfo",
+                "/aspd.ArkService/GetArkInfo",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "GetArkInfo"));
+                .insert(GrpcMethod::new("aspd.ArkService", "GetArkInfo"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_fresh_rounds(
@@ -358,11 +358,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/GetFreshRounds",
+                "/aspd.ArkService/GetFreshRounds",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "GetFreshRounds"));
+                .insert(GrpcMethod::new("aspd.ArkService", "GetFreshRounds"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_round(
@@ -379,9 +379,9 @@ pub mod ark_service_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/arkd.ArkService/GetRound");
+            let path = http::uri::PathAndQuery::from_static("/aspd.ArkService/GetRound");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("arkd.ArkService", "GetRound"));
+            req.extensions_mut().insert(GrpcMethod::new("aspd.ArkService", "GetRound"));
             self.inner.unary(req, path, codec).await
         }
         /// * ONBOARDING *
@@ -403,11 +403,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/RequestOnboardCosign",
+                "/aspd.ArkService/RequestOnboardCosign",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "RequestOnboardCosign"));
+                .insert(GrpcMethod::new("aspd.ArkService", "RequestOnboardCosign"));
             self.inner.unary(req, path, codec).await
         }
         /// * OOR PAYMENTS*
@@ -429,11 +429,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/RequestOorCosign",
+                "/aspd.ArkService/RequestOorCosign",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "RequestOorCosign"));
+                .insert(GrpcMethod::new("aspd.ArkService", "RequestOorCosign"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn post_oor_mailbox(
@@ -451,11 +451,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/PostOorMailbox",
+                "/aspd.ArkService/PostOorMailbox",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "PostOorMailbox"));
+                .insert(GrpcMethod::new("aspd.ArkService", "PostOorMailbox"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn empty_oor_mailbox(
@@ -476,11 +476,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/EmptyOorMailbox",
+                "/aspd.ArkService/EmptyOorMailbox",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "EmptyOorMailbox"));
+                .insert(GrpcMethod::new("aspd.ArkService", "EmptyOorMailbox"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn subscribe_rounds(
@@ -501,11 +501,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/SubscribeRounds",
+                "/aspd.ArkService/SubscribeRounds",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "SubscribeRounds"));
+                .insert(GrpcMethod::new("aspd.ArkService", "SubscribeRounds"));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn submit_payment(
@@ -523,11 +523,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/SubmitPayment",
+                "/aspd.ArkService/SubmitPayment",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "SubmitPayment"));
+                .insert(GrpcMethod::new("aspd.ArkService", "SubmitPayment"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn provide_vtxo_signatures(
@@ -545,11 +545,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/ProvideVtxoSignatures",
+                "/aspd.ArkService/ProvideVtxoSignatures",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "ProvideVtxoSignatures"));
+                .insert(GrpcMethod::new("aspd.ArkService", "ProvideVtxoSignatures"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn provide_forfeit_signatures(
@@ -567,11 +567,11 @@ pub mod ark_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.ArkService/ProvideForfeitSignatures",
+                "/aspd.ArkService/ProvideForfeitSignatures",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.ArkService", "ProvideForfeitSignatures"));
+                .insert(GrpcMethod::new("aspd.ArkService", "ProvideForfeitSignatures"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -680,11 +680,11 @@ pub mod admin_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.AdminService/WalletStatus",
+                "/aspd.AdminService/WalletStatus",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.AdminService", "WalletStatus"));
+                .insert(GrpcMethod::new("aspd.AdminService", "WalletStatus"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn trigger_round(
@@ -702,11 +702,11 @@ pub mod admin_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/arkd.AdminService/TriggerRound",
+                "/aspd.AdminService/TriggerRound",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("arkd.AdminService", "TriggerRound"));
+                .insert(GrpcMethod::new("aspd.AdminService", "TriggerRound"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn stop(
@@ -723,9 +723,9 @@ pub mod admin_service_client {
                     )
                 })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/arkd.AdminService/Stop");
+            let path = http::uri::PathAndQuery::from_static("/aspd.AdminService/Stop");
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("arkd.AdminService", "Stop"));
+            req.extensions_mut().insert(GrpcMethod::new("aspd.AdminService", "Stop"));
             self.inner.unary(req, path, codec).await
         }
     }

--- a/aspd/rpc-protos/aspd.proto
+++ b/aspd/rpc-protos/aspd.proto
@@ -1,7 +1,7 @@
 
 syntax = "proto3";
 
-package arkd;
+package aspd;
 
 /// Public ark service for arkd.
 service ArkService {

--- a/aspd/src/rpc/aspd.rs
+++ b/aspd/src/rpc/aspd.rs
@@ -387,7 +387,7 @@ pub mod ark_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/arkd.ArkService/GetArkInfo" => {
+                "/aspd.ArkService/GetArkInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetArkInfoSvc<T: ArkService>(pub Arc<T>);
                     impl<T: ArkService> tonic::server::UnaryService<super::Empty>
@@ -431,7 +431,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/GetFreshRounds" => {
+                "/aspd.ArkService/GetFreshRounds" => {
                     #[allow(non_camel_case_types)]
                     struct GetFreshRoundsSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -477,7 +477,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/GetRound" => {
+                "/aspd.ArkService/GetRound" => {
                     #[allow(non_camel_case_types)]
                     struct GetRoundSvc<T: ArkService>(pub Arc<T>);
                     impl<T: ArkService> tonic::server::UnaryService<super::RoundId>
@@ -521,7 +521,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/RequestOnboardCosign" => {
+                "/aspd.ArkService/RequestOnboardCosign" => {
                     #[allow(non_camel_case_types)]
                     struct RequestOnboardCosignSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -568,7 +568,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/RequestOorCosign" => {
+                "/aspd.ArkService/RequestOorCosign" => {
                     #[allow(non_camel_case_types)]
                     struct RequestOorCosignSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -614,7 +614,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/PostOorMailbox" => {
+                "/aspd.ArkService/PostOorMailbox" => {
                     #[allow(non_camel_case_types)]
                     struct PostOorMailboxSvc<T: ArkService>(pub Arc<T>);
                     impl<T: ArkService> tonic::server::UnaryService<super::OorVtxo>
@@ -658,7 +658,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/EmptyOorMailbox" => {
+                "/aspd.ArkService/EmptyOorMailbox" => {
                     #[allow(non_camel_case_types)]
                     struct EmptyOorMailboxSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -704,7 +704,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/SubscribeRounds" => {
+                "/aspd.ArkService/SubscribeRounds" => {
                     #[allow(non_camel_case_types)]
                     struct SubscribeRoundsSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -751,7 +751,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/SubmitPayment" => {
+                "/aspd.ArkService/SubmitPayment" => {
                     #[allow(non_camel_case_types)]
                     struct SubmitPaymentSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -797,7 +797,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/ProvideVtxoSignatures" => {
+                "/aspd.ArkService/ProvideVtxoSignatures" => {
                     #[allow(non_camel_case_types)]
                     struct ProvideVtxoSignaturesSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -844,7 +844,7 @@ pub mod ark_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.ArkService/ProvideForfeitSignatures" => {
+                "/aspd.ArkService/ProvideForfeitSignatures" => {
                     #[allow(non_camel_case_types)]
                     struct ProvideForfeitSignaturesSvc<T: ArkService>(pub Arc<T>);
                     impl<
@@ -932,7 +932,7 @@ pub mod ark_service_server {
         }
     }
     impl<T: ArkService> tonic::server::NamedService for ArkServiceServer<T> {
-        const NAME: &'static str = "arkd.ArkService";
+        const NAME: &'static str = "aspd.ArkService";
     }
 }
 /// Generated server implementations.
@@ -1038,7 +1038,7 @@ pub mod admin_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/arkd.AdminService/WalletStatus" => {
+                "/aspd.AdminService/WalletStatus" => {
                     #[allow(non_camel_case_types)]
                     struct WalletStatusSvc<T: AdminService>(pub Arc<T>);
                     impl<T: AdminService> tonic::server::UnaryService<super::Empty>
@@ -1082,7 +1082,7 @@ pub mod admin_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.AdminService/TriggerRound" => {
+                "/aspd.AdminService/TriggerRound" => {
                     #[allow(non_camel_case_types)]
                     struct TriggerRoundSvc<T: AdminService>(pub Arc<T>);
                     impl<T: AdminService> tonic::server::UnaryService<super::Empty>
@@ -1126,7 +1126,7 @@ pub mod admin_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/arkd.AdminService/Stop" => {
+                "/aspd.AdminService/Stop" => {
                     #[allow(non_camel_case_types)]
                     struct StopSvc<T: AdminService>(pub Arc<T>);
                     impl<T: AdminService> tonic::server::UnaryService<super::Empty>
@@ -1208,6 +1208,6 @@ pub mod admin_service_server {
         }
     }
     impl<T: AdminService> tonic::server::NamedService for AdminServiceServer<T> {
-        const NAME: &'static str = "arkd.AdminService";
+        const NAME: &'static str = "aspd.AdminService";
     }
 }


### PR DESCRIPTION
We've renamed the `arkd` executable to `aspd`. I'd like to do the rename in the protobuf file as well.